### PR TITLE
Change Program class to public

### DIFF
--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -303,7 +303,7 @@ namespace Sharphound
 
     #region Console Entrypoint
 
-    internal class Program
+    public class Program
     {
         public static async Task Main(string[] args)
         {


### PR DESCRIPTION
To call the Assembly from external it would be helpful, if the program class is public.
Or if not wanted, adding another class with public identifier would be helpful.