### PR TITLE
Add an option to disable LDAPS Certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ dotnet build
 
   --secureldap               (Default: false) Connect to LDAP SSL instead of regular LDAP
 
+  --disablecertverification  (Default: false) Disables certificate verification when using LDAPS
+
   --disablesigning           (Default: false) Disables Kerberos Signing/Sealing
 
   --skipportcheck            (Default: false) Skip checking if 445 is open

--- a/src/Client/Flags.cs
+++ b/src/Client/Flags.cs
@@ -13,6 +13,7 @@
         public bool NoZip { get; set; }
         public bool InvalidateCache { get; set; }
         public bool SecureLDAP { get; set; }
+        public bool DisableCertVerification { get; set; }
         public bool DisableKerberosSigning { get; set; }
         public bool SkipPortScan { get; set; }
         public bool ExcludeDomainControllers { get; set; }

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -86,6 +86,9 @@ namespace Sharphound
         [Option(HelpText = "Connect to LDAP SSL instead of regular LDAP", Default = false)]
         public bool SecureLDAP { get; set; }
 
+        [Option(HelpText = "Disables certificate verification when using LDAPS", Default = false)]
+        public bool DisableCertVerification { get; set; }
+
         [Option(HelpText = "Disables Kerberos Signing/Sealing", Default = false)]
         public bool DisableSigning { get; set; }
 

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -354,6 +354,7 @@ namespace Sharphound
                     SkipPortScan = options.SkipPortCheck,
                     DisableKerberosSigning = options.DisableSigning,
                     SecureLDAP = options.SecureLDAP,
+                    DisableCertVerification = options.DisableCertVerification,
                     InvalidateCache = options.RebuildCache,
                     NoZip = options.NoZip,
                     NoOutput = false,
@@ -371,6 +372,7 @@ namespace Sharphound
                     Port = options.LDAPPort,
                     DisableSigning = options.DisableSigning,
                     SSL = options.SecureLDAP,
+                    DisableCertVerification = options.DisableCertVerification,
                     AuthType = AuthType.Negotiate
                 };
 


### PR DESCRIPTION
By default, DotNet (which SharpHound uses) perform strong verification of LDAPS TLS certificates. 
This is unlike `bloodhound-python` which [does not verify SSL](https://github.com/cannatag/ldap3/blob/master/ldap3/core/tls.py#L73) on its queries. 

DotNet TLS verification [is notoriously tricky](https://stackoverflow.com/questions/58165262/net-program-does-not-get-validated-server-certificate), and [sometimes fail](https://stackoverflow.com/questions/28761249/x509certificate2-verify-returns-false-always) even trough the certificate is perfectly valid (For instance, because the CRL cannot be reached or because TLS 1.3 can't be used..). This can be a problem when running bloodhound in LDAPS-only environments.

This PR add an option to disable verification of the TLS certificate when doing LDAPS queries

(Related to https://github.com/BloodHoundAD/SharpHoundCommon/pull/30)
