### PR TITLE
DumpSMSAPassword: added the value of sMSA to computer objects

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -173,6 +173,7 @@ namespace Sharphound.Runtime
                 ret.AllowedToDelegate = computerProps.AllowedToDelegate;
                 ret.AllowedToAct = computerProps.AllowedToAct;
                 ret.HasSIDHistory = computerProps.SidHistory;
+                ret.SMSA = computerProps.SMSA;
             }
 
             if (!_methods.IsComputerCollectionSet())

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -173,7 +173,7 @@ namespace Sharphound.Runtime
                 ret.AllowedToDelegate = computerProps.AllowedToDelegate;
                 ret.AllowedToAct = computerProps.AllowedToAct;
                 ret.HasSIDHistory = computerProps.SidHistory;
-                ret.SMSA = computerProps.SMSA;
+                ret.DumpSMSAPassword = computerProps.DumpSMSAPassword;
             }
 
             if (!_methods.IsComputerCollectionSet())


### PR DESCRIPTION
Computer objects now contain a key named `SMSA`. Refer https://github.com/BloodHoundAD/SharpHoundCommon/pull/46 for its content.

For more info, see https://github.com/BloodHoundAD/BloodHound/issues/624.