### PR TITLE
Added option to do Session Enumeration as local Admin User

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ dotnet build
 
   --statusinterval           (Default: 30000) Interval in which to display status in milliseconds
 
+  --localadminsessionenum    Specify if you want to use a dedicated LOCAL user for session enumeration
+
+  --localadminusername       Specify the username of the localadmin for session enumeration
+
+  --localadminpassword       Specify the password of the localadmin for session enumeration
+
   -v                         (Default: 2) Enable verbose output. Lower is more verbose
 
   --help                     Display this help screen.

--- a/src/BaseContext.cs
+++ b/src/BaseContext.cs
@@ -115,9 +115,9 @@ namespace Sharphound
         }
 
         public string[] Domains { get; set; }
-        public string LocalAdminUsername { get; internal set; }
-        public string LocalAdminPassword { get; internal set; }
-        public bool LocalAdminSessionEnum { get; internal set; }
+        public string LocalAdminUsername { get; set; }
+        public string LocalAdminPassword { get; set; }
+        public bool LocalAdminSessionEnum { get; set; }
 
         // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
         // ~Context()

--- a/src/BaseContext.cs
+++ b/src/BaseContext.cs
@@ -115,6 +115,9 @@ namespace Sharphound
         }
 
         public string[] Domains { get; set; }
+        public string LocalAdminUsername { get; internal set; }
+        public string LocalAdminPassword { get; internal set; }
+        public bool LocalAdminSessionEnum { get; internal set; }
 
         // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
         // ~Context()

--- a/src/Client/Context.cs
+++ b/src/Client/Context.cs
@@ -58,6 +58,10 @@ namespace Sharphound.Client
         int Jitter { get; set; }
         int PortScanTimeout { get; set; }
 
+        public string LocalAdminUsername { get; set; }
+
+        public string LocalAdminPassword { get; set; }
+
         ResolvedCollectionMethod ResolvedCollectionMethods { get; set; }
 
         /// <summary>

--- a/src/Client/Flags.cs
+++ b/src/Client/Flags.cs
@@ -1,4 +1,6 @@
-﻿namespace Sharphound.Client
+﻿using SharpHoundCommonLib.OutputTypes;
+
+namespace Sharphound.Client
 {
     public class Flags
     {
@@ -23,5 +25,7 @@
         public bool DCOnly { get; set; }
         public bool PrettyPrint { get; set; }
         public bool SearchForest { get; set; }
+        public bool LocalAdminSessionEnum { get; set; }
+        
     }
 }

--- a/src/Client/Flags.cs
+++ b/src/Client/Flags.cs
@@ -25,7 +25,6 @@ namespace Sharphound.Client
         public bool DCOnly { get; set; }
         public bool PrettyPrint { get; set; }
         public bool SearchForest { get; set; }
-        public bool LocalAdminSessionEnum { get; set; }
-        
+        public bool DoLocalAdminSessionEnum { get; set; }
     }
 }

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -76,8 +76,13 @@ namespace Sharphound
         [Option(HelpText = "Password for LDAP", Default = null)]
         public string LDAPPassword { get; set; }
 
-        [Option(HelpText = "Override domain controller to pull LDAP from. This option can result in data loss",
-            Default = null)]
+        [Option(HelpText = "Username for local Administrator", Default = null)]
+        public string LocalAdminUsername { get; set; }
+
+        [Option(HelpText = "Password for local Administrator", Default = null)]
+        public string LocalAdminPassword { get; set; }
+
+        [Option(HelpText = "Override domain controller to pull LDAP from. This option can result in data loss", Default = null)]
         public string DomainController { get; set; }
 
         [Option(HelpText = "Override port for LDAP", Default = 0)]

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -76,10 +76,13 @@ namespace Sharphound
         [Option(HelpText = "Password for LDAP", Default = null)]
         public string LDAPPassword { get; set; }
 
-        [Option(HelpText = "Username for local Administrator", Default = null)]
+        [Option(HelpText = "Do the session enumeration with local admin credentials instead of domain credentials", Default = false)]
+        public bool DoLocalAdminSessionEnum { get; set; }
+
+        [Option(HelpText = "Username for local Administrator to be used if DoLocalAdminSessionEnum is set", Default = null)]
         public string LocalAdminUsername { get; set; }
 
-        [Option(HelpText = "Password for local Administrator", Default = null)]
+        [Option(HelpText = "Password for local Administrator to be used if DoLocalAdminSessionEnum is set", Default = null)]
         public string LocalAdminPassword { get; set; }
 
         [Option(HelpText = "Override domain controller to pull LDAP from. This option can result in data loss", Default = null)]

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -38,7 +38,7 @@ namespace Sharphound.Runtime
             _ldapPropertyProcessor = new LDAPPropertyProcessor(context.LDAPUtils);
             _domainTrustProcessor = new DomainTrustProcessor(context.LDAPUtils);
             _computerAvailability = new ComputerAvailability(context.PortScanTimeout, skipPortScan: context.Flags.SkipPortScan, skipPasswordCheck: context.Flags.SkipPasswordAgeCheck);
-            _computerSessionProcessor = new ComputerSessionProcessor(context.LDAPUtils, LocalAdminSessionEnum: context.Flags.LocalAdminSessionEnum);
+            _computerSessionProcessor = new ComputerSessionProcessor(context.LDAPUtils, doLocalAdminSessionEnum: context.Flags.DoLocalAdminSessionEnum, localAdminUsername: context.LocalAdminUsername, localAdminPassword: context.LocalAdminPassword);
             _groupProcessor = new GroupProcessor(context.LDAPUtils);
             _containerProcessor = new ContainerProcessor(context.LDAPUtils);
             _gpoLocalGroupProcessor = new GPOLocalGroupProcessor(context.LDAPUtils);

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -38,7 +38,7 @@ namespace Sharphound.Runtime
             _ldapPropertyProcessor = new LDAPPropertyProcessor(context.LDAPUtils);
             _domainTrustProcessor = new DomainTrustProcessor(context.LDAPUtils);
             _computerAvailability = new ComputerAvailability(context.PortScanTimeout, skipPortScan: context.Flags.SkipPortScan, skipPasswordCheck: context.Flags.SkipPasswordAgeCheck);
-            _computerSessionProcessor = new ComputerSessionProcessor(context.LDAPUtils);
+            _computerSessionProcessor = new ComputerSessionProcessor(context.LDAPUtils, LocalAdminSessionEnum: context.Flags.LocalAdminSessionEnum);
             _groupProcessor = new GroupProcessor(context.LDAPUtils);
             _containerProcessor = new ContainerProcessor(context.LDAPUtils);
             _gpoLocalGroupProcessor = new GPOLocalGroupProcessor(context.LDAPUtils);

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -371,7 +371,10 @@ namespace Sharphound
                         CollectAllProperties = options.CollectAllProperties,
                         DCOnly = dconly,
                         PrettyPrint = options.PrettyPrint,
-                        SearchForest = options.SearchForest
+                        SearchForest = options.SearchForest,
+                        LocalAdminSessionEnum = options.LocalAdminSessionEnum,
+                        LocalAdminUsername = options.LocalAdminUsername,
+                        LocalAdminPassword = options.LocalAdminPassword
                     };
 
                     var ldapOptions = new LDAPConfig
@@ -397,7 +400,8 @@ namespace Sharphound
                         ldapOptions.Password = options.LDAPPassword;
                     }
 
-                    IContext context = new BaseContext(logger, ldapOptions, flags)
+                    
+                        IContext context = new BaseContext(logger, ldapOptions, flags)
                     {
                         DomainName = options.Domain,
                         CacheFileName = options.CacheName,
@@ -417,7 +421,11 @@ namespace Sharphound
                         LoopDuration = options.LoopDuration,
                         LoopInterval = options.LoopInterval,
                         ZipPassword = options.ZipPassword,
-                        IsFaulted = false
+                        IsFaulted = false,
+                        LocalAdminSessionEnum = options.LocalAdminSessionEnum,
+                        LocalAdminUsername = options.LocalAdminUsername,
+                        LocalAdminPassword = options.LocalAdminPassword
+
                     };
 
                     var cancellationTokenSource = new CancellationTokenSource();

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -372,9 +372,7 @@ namespace Sharphound
                         DCOnly = dconly,
                         PrettyPrint = options.PrettyPrint,
                         SearchForest = options.SearchForest,
-                        LocalAdminSessionEnum = options.LocalAdminSessionEnum,
-                        LocalAdminUsername = options.LocalAdminUsername,
-                        LocalAdminPassword = options.LocalAdminPassword
+                        DoLocalAdminSessionEnum = options.DoLocalAdminSessionEnum,
                     };
 
                     var ldapOptions = new LDAPConfig
@@ -401,7 +399,7 @@ namespace Sharphound
                     }
 
                     
-                        IContext context = new BaseContext(logger, ldapOptions, flags)
+                    IContext context = new BaseContext(logger, ldapOptions, flags)
                     {
                         DomainName = options.Domain,
                         CacheFileName = options.CacheName,
@@ -422,7 +420,6 @@ namespace Sharphound
                         LoopInterval = options.LoopInterval,
                         ZipPassword = options.ZipPassword,
                         IsFaulted = false,
-                        LocalAdminSessionEnum = options.LocalAdminSessionEnum,
                         LocalAdminUsername = options.LocalAdminUsername,
                         LocalAdminPassword = options.LocalAdminPassword
 

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -82,7 +82,7 @@ namespace Sharphound
         /// <param name="options"></param>
         /// <param name="options2"></param>
         /// <returns></returns>
-        public IContext Initialize(IContext context, LDAPConfig options)
+        public IContext Initialize(IContext context, LDAPConfig options, Sharphound.Options options2)
         {
             context.Logger.LogTrace("Entering initialize link");
             JsonConvert.DefaultSettings = () => new JsonSerializerSettings

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -80,6 +80,7 @@ namespace Sharphound
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
+        /// <param name="options2"></param>
         /// <returns></returns>
         public IContext Initialize(IContext context, LDAPConfig options)
         {
@@ -102,6 +103,28 @@ namespace Sharphound
                 context.Logger.LogTrace("You must specify both LdapUsername and LdapPassword if using these options!");
                 context.Flags.IsFaulted = true;
                 return context;
+            }
+            
+            // Check to make sure both Local Admin Session Enum options are set if either is set
+
+            if (options2.LocalAdminPassword != null && options2.LocalAdminUsername == null ||
+                options2.LocalAdminUsername != null && options2.LocalAdminPassword == null)
+            {
+                context.Logger.LogTrace("You must specify both LocalAdminUsername and LocalAdminPassword if using these options!");
+                context.Flags.IsFaulted = true;
+                return context;
+            }
+
+            // Check to make sure doLocalAdminSessionEnum is set when specifying localadmin and password
+
+            if (options2.LocalAdminPassword != null || options2.LocalAdminUsername != null)
+                { 
+                if (options2.DoLocalAdminSessionEnum == false)
+                {
+                    context.Logger.LogTrace("You must use the --doLocalAdminSessionEnum switch in combination with --LocalAdminUsername and --LocalAdminPassword!");
+                    context.Flags.IsFaulted = true;
+                    return context;
+                }
             }
 
             //Check some loop options


### PR DESCRIPTION
This is the needed PR to SharpHound that allows to set an option to do session enumeration with a dedicated local (admin) user.
Credits to @eversinc33 how helped me a lot with this.

The situation with more recent pentests and red-team engagements is most likely that you see higher numbers of Windows Server 2016 + as well as Windows 10 1607 +. So the privileged session enumeration via NetWkstaUserEnum needs to be with a user that has local admin rights. Once gaining a foothold or in an assumed breach scenario we will most likely do not have these rights.
But, and that is very common, we do local priv esc on the client, fetch the local admin's credentials, and it happens to be some lame password that is reused accross a large scope of systems - worst case even servers. Same applies to once we get a server's local admin password, and this one is reused.

SharpHound was not able to do this, because it would run the session checks in the context of the user that runs the collector.
What we did was to add 3 new flags:

-DoLocalAdminSessionEnum
-LocalAdminUsername
-LocalAdminPassword

We added a new library (Impersonate.cs ) that allows us to impersonate another remote local user in the current user's context via the LOGON32_PROVIDER_WINNT50 option from the advapi32.dll.
That allows us to wrap the session enumeration stuff inside an impersonated user's context and overcome the limitations mentioned above.
Credits to @phillipharding for this library.

Everything else is done as the running user, so no impact on the rest of what SharpHound is doing.

I created a POC video demonsrating how it works:
https://www.youtube.com/watch?v=mMpNs3MXISM

BloodHound documentation was extended accordingly as well as the SharpHoundCommon project itself. Accordings PRs were opened.
https://github.com/BloodHoundAD/SharpHoundCommon/pull/47
https://github.com/BloodHoundAD/BloodHound/pull/646