### PR TITLE
Prompt for --LDAPPassword interactively if password not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ dotnet build
 
   --ldapusername             Username for LDAP
 
-  --ldappassword             Password for LDAP
+  --ldappassword             Password for LDAP. If not specified, an interactive prompt will be used
 
   --domaincontroller         Override domain controller to pull LDAP from. This option can result in data loss
 

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -73,7 +73,7 @@ namespace Sharphound
         [Option(HelpText = "Username for LDAP", Default = null)]
         public string LDAPUsername { get; set; }
 
-        [Option(HelpText = "Password for LDAP", Default = null)]
+        [Option(HelpText = "Password for LDAP. If not specified, an interactive prompt will be used", Default = null)]
         public string LDAPPassword { get; set; }
 
         [Option(HelpText = "Override domain controller to pull LDAP from. This option can result in data loss",

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -21,6 +21,7 @@ using System.DirectoryServices.Protocols;
 using System.IO;
 using System.Linq;
 using System.Security.Principal;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
@@ -389,8 +390,31 @@ namespace Sharphound
                     {
                         if (options.LDAPPassword == null)
                         {
-                            logger.LogError("You must specify LDAPPassword if using the LDAPUsername options");
-                            return;
+                            logger.LogInformation("Prompting for interactive LDAPPassword");
+                            StringBuilder passwordBuilder = new StringBuilder();
+                            Console.Write("LDAPPassword: ");
+                            while (true)
+                            {
+                                ConsoleKeyInfo key = Console.ReadKey(true);
+                                if (key.Key == ConsoleKey.Enter)
+                                    break;
+                                
+                                if (key.Key == ConsoleKey.Backspace)
+                                {
+                                    // Don't allow user to backspace through prompt
+                                    if (passwordBuilder.Length > 0)
+                                    {
+                                        passwordBuilder.Length--;
+                                        Console.Write("\b \b");
+                                    }
+                                    continue;
+                                }
+
+                                passwordBuilder.Append(key.KeyChar);
+                                Console.Write("*");
+                            }
+                            Console.WriteLine();
+                            options.LDAPPassword = passwordBuilder.ToString();
                         }
 
                         ldapOptions.Username = options.LDAPUsername;


### PR DESCRIPTION
This small PR addresses #44. 

If `--LDAPUsername` is utilized and `--LDAPPassword` is not, a password can be entered dynamically.

Example:
```
SharpHound.exe --ldapusername myuser
2023-06-25T19:02:39.8096739-07:00|INFORMATION|This version of SharpHound is compatible with the 4.3.1 Release of BloodHound
2023-06-25T19:02:39.8799821-07:00|INFORMATION|Resolved Collection Methods: Group, LocalAdmin, Session, Trusts, ACL, Container, RDP, ObjectProps, DCOM, SPNTargets, PSRemote
2023-06-25T19:02:39.8809888-07:00|INFORMATION|Prompting for interactive LDAPPassword
LDAPPassword: *******
2023-06-25T19:02:44.4287920-07:00|INFORMATION|Initializing SharpHound at 7:02 PM on 6/25/2023
````