### PR TITLE
Chore: Remove hard-coded compatibility log

### DIFF
--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -335,7 +335,6 @@ namespace Sharphound
         public static async Task Main(string[] args)
         {
             var logger = new BasicLogger((int)LogLevel.Information);
-            logger.LogInformation("This version of SharpHound is compatible with the 4.3.1 Release of BloodHound");
             try
             {
                 var parser = new Parser(with =>


### PR DESCRIPTION
Maintaining hardcoded references for compatibility will be a losing battle. Remove hard-coded compatibility log.