### PR TITLE
BED-3868: Build contains edges from DNs

### DIFF
--- a/src/Producers/BaseProducer.cs
+++ b/src/Producers/BaseProducer.cs
@@ -76,7 +76,7 @@ namespace Sharphound.Producers
             {
                 if ((methods & ResolvedCollectionMethod.Container) != 0)
                 {
-                    query = query.AddContainers().AddDomains();
+                    query = query.AddComputers().AddContainers().AddUsers().AddGroups().AddDomains().AddOUs().AddGPOs();
                     props.AddRange(CommonProperties.ContainerProps);
                 }
 

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -425,11 +425,6 @@ namespace Sharphound.Runtime
                 }
             }
 
-            if ((_methods & ResolvedCollectionMethod.Container) != 0)
-            {
-                ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
-            }
-
             return ret;
         }
 
@@ -465,6 +460,7 @@ namespace Sharphound.Runtime
 
             if ((_methods & ResolvedCollectionMethod.Container) != 0)
             {
+                ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
                 ret.Properties.Add("blocksinheritance",
                     ContainerProcessor.ReadBlocksInheritance(entry.GetProperty("gpoptions")));
                 ret.Links = _containerProcessor.ReadContainerGPLinks(resolvedSearchResult, entry).ToArray();

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -135,6 +135,11 @@ namespace Sharphound.Runtime
                 ret.SPNTargets = targets.ToArray();
             }
 
+            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            {
+                ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
+            }
+
             return ret;
         }
 
@@ -181,6 +186,11 @@ namespace Sharphound.Runtime
                 ret.AllowedToAct = computerProps.AllowedToAct;
                 ret.HasSIDHistory = computerProps.SidHistory;
                 ret.DumpSMSAPassword = computerProps.DumpSMSAPassword;
+            }
+
+            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            {
+                ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
             }
 
             if (!_methods.IsComputerCollectionSet())
@@ -306,6 +316,11 @@ namespace Sharphound.Runtime
                 }
             }
 
+            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            {
+                ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
+            }
+
             return ret;
         }
 
@@ -368,7 +383,6 @@ namespace Sharphound.Runtime
 
             if ((_methods & ResolvedCollectionMethod.Container) != 0)
             {
-                ret.ChildObjects = _containerProcessor.GetContainerChildObjects(resolvedSearchResult, entry).ToArray();
                 ret.Links = _containerProcessor.ReadContainerGPLinks(resolvedSearchResult, entry).ToArray();
             }
 
@@ -410,7 +424,11 @@ namespace Sharphound.Runtime
                         ret.Properties);
                 }
             }
-                
+
+            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            {
+                ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
+            }
 
             return ret;
         }
@@ -447,7 +465,6 @@ namespace Sharphound.Runtime
 
             if ((_methods & ResolvedCollectionMethod.Container) != 0)
             {
-                ret.ChildObjects = _containerProcessor.GetContainerChildObjects(resolvedSearchResult, entry).ToArray();
                 ret.Properties.Add("blocksinheritance",
                     ContainerProcessor.ReadBlocksInheritance(entry.GetProperty("gpoptions")));
                 ret.Links = _containerProcessor.ReadContainerGPLinks(resolvedSearchResult, entry).ToArray();
@@ -477,7 +494,7 @@ namespace Sharphound.Runtime
             ret.Properties.Add("highvalue", false);
 
             if ((_methods & ResolvedCollectionMethod.Container) != 0)
-                ret.ChildObjects = _containerProcessor.GetContainerChildObjects(entry.DistinguishedName).ToArray();
+                ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
 
             if ((_methods & ResolvedCollectionMethod.ACL) != 0)
             {

--- a/src/Writers/JsonDataWriter.cs
+++ b/src/Writers/JsonDataWriter.cs
@@ -22,7 +22,7 @@ namespace Sharphound.Writers
         private string _fileName;
         private JsonSerializerSettings _serializerSettings;
 
-        private const int DataVersion = 5;
+        private const int DataVersion = 6;
 
         /// <summary>
         ///     Creates a new instance of a JSONWriter using the specified datatype and program context


### PR DESCRIPTION
Update SH to use ContainedBy instead of ChildObjects. This will make BloodHound build Contains edges based on DistiguishedName.