### PR TITLE
Remove version number from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
----
-SharpHound Open Source Client version: 2.0.0
----
-
 # SharpHound
 
 ![GitHub all releases](https://img.shields.io/github/downloads/BloodHoundAD/SharpHound/total)


### PR DESCRIPTION
Why have a version number in the readme?

Right now it says 2.0.0 and the latest release is 2.0.1. It seems bothersome to keep updating it.

![image](https://github.com/BloodHoundAD/SharpHound/assets/12843299/15279cbe-3f91-4474-9b80-deda935bf4dc)
