### PR TITLE
feat: add certservices collection method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ dotnet build
 
 SharpHound is designed targeting .Net 4.6.2. SharpHound must be run from the context of a domain user, either directly through a logon or through another method such as RUNAS.
 
-
 # SharpHound
 
 ```csharp
@@ -28,9 +27,10 @@ dotnet build
 ```
 
 # CLI
+
 ```
   -c, --collectionmethods    (Default: Default) Collection Methods: Container, Group, LocalGroup, GPOLocalGroup,
-                             Session, LoggedOn, ObjectProps, ACL, ComputerOnly, Trusts, Default, RDP, DCOM, DCOnly, CARegistry, DCRegistry
+                             Session, LoggedOn, ObjectProps, ACL, ComputerOnly, Trusts, Default, RDP, DCOM, DCOnly, CARegistry, DCRegistry, CertServices
 
   -d, --domain               Specify domain to enumerate
 
@@ -75,7 +75,7 @@ dotnet build
   --ldapport                 (Default: 0) Override port for LDAP
 
   --secureldap               (Default: false) Connect to LDAP SSL instead of regular LDAP
-  
+
   --disablecertverification  (Default: false) Disable certificate verification for secure LDAP
 
   --disablesigning           (Default: false) Disables Kerberos Signing/Sealing
@@ -83,7 +83,7 @@ dotnet build
   --skipportcheck            (Default: false) Skip checking if 445 is open
 
   --portchecktimeout         (Default: 500) Timeout for port checks in milliseconds
-  
+
   --skippasswordcheck        (Default: false) Skip PwdLastSet age check when checking computers
 
   --excludedcs               (Default: false) Exclude domain controllers from session/localgroup enumeration (mostly for

--- a/src/Client/Enums.cs
+++ b/src/Client/Enums.cs
@@ -26,6 +26,7 @@
         ComputerOnly,
         CARegistry,
         DCRegistry,
+        CertServices,
         All
     }
 }

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -14,7 +14,7 @@ namespace Sharphound
         // Options that affect what is collected
         [Option('c', "collectionmethods", Default = new[] { "Default" },
             HelpText =
-                "Collection Methods: Group, LocalGroup, LocalAdmin, RDP, DCOM, PSRemote, Session, Trusts, ACL, Container, ComputerOnly, GPOLocalGroup, LoggedOn, ObjectProps, SPNTargets, UserRights, Default, DCOnly, CARegistry, DCRegistry, All")]
+                "Collection Methods: Group, LocalGroup, LocalAdmin, RDP, DCOM, PSRemote, Session, Trusts, ACL, Container, ComputerOnly, GPOLocalGroup, LoggedOn, ObjectProps, SPNTargets, UserRights, Default, DCOnly, CARegistry, DCRegistry, CertServices, All")]
         public IEnumerable<string> CollectionMethods { get; set; }
 
         [Option('d', "domain", Default = null, HelpText = "Specify domain to enumerate")]
@@ -61,7 +61,7 @@ namespace Sharphound
 
         [Option(HelpText = "Don't zip files", Default = false)]
         public bool NoZip { get; set; }
-        
+
         [Option(HelpText = "Password protects the zip with the specified password", Default = null)]
         public string ZipPassword { get; set; }
 
@@ -87,7 +87,7 @@ namespace Sharphound
 
         [Option(HelpText = "Connect to LDAP SSL instead of regular LDAP", Default = false)]
         public bool SecureLDAP { get; set; }
-        
+
         [Option(HelpText = "Disables certificate verification when using LDAPS", Default = false)]
         public bool DisableCertVerification { get; set; }
 
@@ -97,10 +97,10 @@ namespace Sharphound
         //Options that affect how enumeration is performed
         [Option(HelpText = "Skip checking if 445 is open", Default = false)]
         public bool SkipPortCheck { get; set; }
-        
+
         [Option(HelpText = "Timeout for port checks in milliseconds", Default = 500)]
         public int PortCheckTimeout { get; set; }
-        
+
         [Option(HelpText = "Skip check for PwdLastSet when enumerating computers", Default = false)]
         public bool SkipPasswordCheck { get; set; }
 
@@ -114,7 +114,7 @@ namespace Sharphound
         [Option(HelpText = "Add jitter to throttle (percent)")]
         public int Jitter { get; set; }
 
-        [Option('t',"threads", HelpText = "Number of threads to run enumeration with", Default = 50)]
+        [Option('t', "threads", HelpText = "Number of threads to run enumeration with", Default = 50)]
         public int Threads { get; set; }
 
         [Option(HelpText = "Skip registry session enumeration")]
@@ -133,10 +133,10 @@ namespace Sharphound
         [Option('l', "Loop", HelpText = "Loop computer collection")]
         public bool Loop { get; set; }
 
-        [Option(HelpText="Loop duration (hh:mm:ss - 05:00:00 is 5 hours, default: 2 hrs)")]
+        [Option(HelpText = "Loop duration (hh:mm:ss - 05:00:00 is 5 hours, default: 2 hrs)")]
         public TimeSpan LoopDuration { get; set; }
 
-        [Option(HelpText="Add delay between loops (hh:mm:ss - 00:03:00 is 3 minutes)")] public TimeSpan LoopInterval { get; set; }
+        [Option(HelpText = "Add delay between loops (hh:mm:ss - 00:03:00 is 3 minutes)")] public TimeSpan LoopInterval { get; set; }
 
         //Misc Options
         [Option(HelpText = "Interval in which to display status in milliseconds", Default = 30000)]
@@ -189,6 +189,7 @@ namespace Sharphound
                     CollectionMethodOptions.ComputerOnly => ResolvedCollectionMethod.ComputerOnly,
                     CollectionMethodOptions.CARegistry => ResolvedCollectionMethod.CARegistry,
                     CollectionMethodOptions.DCRegistry => ResolvedCollectionMethod.DCRegistry,
+                    CollectionMethodOptions.CertServices => ResolvedCollectionMethod.CertServices,
                     CollectionMethodOptions.All => ResolvedCollectionMethod.All,
                     CollectionMethodOptions.None => ResolvedCollectionMethod.None,
                     _ => throw new ArgumentOutOfRangeException()
@@ -234,7 +235,7 @@ namespace Sharphound
                     resolved ^= ResolvedCollectionMethod.LocalAdmin;
                     updates.Add("[-] Removed LocalAdmin Collection");
                 }
-                
+
                 if ((resolved & ResolvedCollectionMethod.CARegistry) != 0)
                 {
                     resolved ^= ResolvedCollectionMethod.CARegistry;

--- a/src/PowerShell/Template.ps1
+++ b/src/PowerShell/Template.ps1
@@ -34,6 +34,7 @@
             DcOnly - Collects Group Membership, ACLs, ObjectProps, Trusts, Containers, and GPO Admins
             CARegistry - Collect ADCS properties from registry of Certificate Authority servers
             DCRegistry - Collect properties from registry of Domain Controller servers
+            CertServices - Collect ADCS properties from Certificate Services
             All - Collect all data
 
         This can be a list of comma separated valued as well to run multiple collection methods!

--- a/src/Producers/ComputerFileProducer.cs
+++ b/src/Producers/ComputerFileProducer.cs
@@ -30,7 +30,7 @@ namespace Sharphound.Producers
             var computerFile = Context.ComputerFile;
             var cancellationToken = Context.CancellationTokenSource.Token;
 
-            var ldapData = CreateLDAPData();
+            var ldapData = CreateDefaultNCData();
 
             try
             {

--- a/src/Producers/LdapProducer.cs
+++ b/src/Producers/LdapProducer.cs
@@ -26,7 +26,7 @@ namespace Sharphound.Producers
         {
             var cancellationToken = Context.CancellationTokenSource.Token;
 
-            var ldapData = CreateLDAPData();
+            var ldapData = CreateDefaultNCData();
 
             var log = Context.Logger;
             var utils = Context.LDAPUtils;
@@ -67,7 +67,7 @@ namespace Sharphound.Producers
                         { "collected", true },
                     }
                 });
-                
+
                 foreach (var searchResult in Context.LDAPUtils.QueryLDAP(ldapData.Filter.GetFilter(), SearchScope.Subtree,
                              ldapData.Props.Distinct().ToArray(), cancellationToken, domain.Name,
                              adsPath: Context.SearchBase,
@@ -83,7 +83,7 @@ namespace Sharphound.Producers
                     Context.Logger.LogTrace("Producer wrote {DistinguishedName} to channel", searchResult.DistinguishedName);
                 }
             }
-            
+
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Sharphound.Producers
                     Context.Logger.LogTrace("Skipping already collected config NC '{path}' for domain {Domain}", configAdsPath, domain.Name);
                 }
             }
-            
+
         }
 
     }

--- a/src/Producers/StealthProducer.cs
+++ b/src/Producers/StealthProducer.cs
@@ -25,7 +25,7 @@ namespace Sharphound.Producers
 
         public StealthProducer(IContext context, Channel<ISearchResultEntry> channel, Channel<OutputBase> outputChannel) : base(context, channel, outputChannel)
         {
-            var ldapData = CreateLDAPData();
+            var ldapData = CreateDefaultNCData();
             _query = ldapData.Filter;
             _props = ldapData.Props;
 
@@ -124,7 +124,7 @@ namespace Sharphound.Producers
                     }
                 });
             }
-            
+
 
 
             // Loop over the paths we grabbed, and resolve them to sids.


### PR DESCRIPTION
This changeset adds the CertServices collection handling associated with splitting ADCS collection into three parts instead of two. 