### PR TITLE
ADCS Data collection consistency fixes

### DIFF
--- a/src/BaseContext.cs
+++ b/src/BaseContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,6 +64,8 @@ namespace Sharphound
         {
             CurrentLoopTime = $"{DateTime.Now:yyyyMMddHHmmss}";
         }
+
+        public HashSet<string> CollectedDomainSids { get; } = new();
 
         public async Task DoDelay()
         {

--- a/src/Client/Context.cs
+++ b/src/Client/Context.cs
@@ -75,5 +75,6 @@ namespace Sharphound.Client
         string ResolveFileName(string filename, string extension, bool addTimestamp);
         EnumerationDomain[] Domains { get; set; }
         void UpdateLoopTime();
+        public HashSet<string> CollectedDomainSids { get; }
     }
 }

--- a/src/Producers/BaseProducer.cs
+++ b/src/Producers/BaseProducer.cs
@@ -130,7 +130,7 @@ namespace Sharphound.Producers
 
                 if ((methods & ResolvedCollectionMethod.DCRegistry) != 0)
                 {
-                    query = query.AddComputers();
+                    query = query.AddComputers(CommonFilters.DomainControllers);
                     props.AddRange(CommonProperties.ComputerMethodProps);
                 }
             }

--- a/src/Producers/BaseProducer.cs
+++ b/src/Producers/BaseProducer.cs
@@ -169,6 +169,9 @@ namespace Sharphound.Producers
             {
                 query = allObjectTypesQuery;
                 props.AddRange(CommonProperties.CertAbuseProps);
+                props.AddRange(CommonProperties.ObjectPropsProps);
+                props.AddRange(CommonProperties.ContainerProps);
+                props.AddRange(CommonProperties.ACLProps);
             }
 
             if ((methods & ResolvedCollectionMethod.Container) != 0)

--- a/src/Producers/LdapProducer.cs
+++ b/src/Producers/LdapProducer.cs
@@ -76,7 +76,7 @@ namespace Sharphound.Producers
                 foreach (var searchResult in Context.LDAPUtils.QueryLDAP(ldapData.Filter.GetFilter(), SearchScope.Subtree,
                              ldapData.Props.Distinct().ToArray(), cancellationToken, domain.Name,
                              adsPath: Context.SearchBase,
-                             includeAcl: (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.ACL) != 0))
+                             includeAcl: (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.ACL) != 0 || (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.CertServices) != 0))
                 {
                     var l = searchResult.DistinguishedName.ToLower();
                     if (l.Contains("cn=domainupdates,cn=system"))
@@ -114,7 +114,7 @@ namespace Sharphound.Producers
                     foreach (var searchResult in Context.LDAPUtils.QueryLDAP(configNcData.Filter.GetFilter(), SearchScope.Subtree,
                                 configNcData.Props.Distinct().ToArray(), cancellationToken, domain.Name,
                                 adsPath: configAdsPath,
-                                includeAcl: (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.ACL) != 0))
+                                includeAcl: (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.ACL) != 0 || (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.CertServices) != 0))
                     {
                         await Channel.Writer.WriteAsync(searchResult, cancellationToken);
                         Context.Logger.LogTrace("Producer wrote {DistinguishedName} to channel", searchResult.DistinguishedName);

--- a/src/Producers/LdapProducer.cs
+++ b/src/Producers/LdapProducer.cs
@@ -44,7 +44,7 @@ namespace Sharphound.Producers
 
             foreach (var domain in Context.Domains)
             {
-                Context.Logger.LogInformation("Beginning LDAP search for {Domain}", domain);
+                Context.Logger.LogInformation("Beginning LDAP search for {Domain}", domain.Name);
                 //Do a basic  LDAP search and grab results
                 var successfulConnect = false;
                 try
@@ -64,14 +64,7 @@ namespace Sharphound.Producers
                     continue;
                 }
 
-                await OutputChannel.Writer.WriteAsync(new Domain
-                {
-                    ObjectIdentifier = domain.DomainSid,
-                    Properties = new Dictionary<string, object>
-                    {
-                        { "collected", true },
-                    }
-                });
+                Context.CollectedDomainSids.Add(domain.DomainSid);
 
                 foreach (var searchResult in Context.LDAPUtils.QueryLDAP(ldapData.Filter.GetFilter(), SearchScope.Subtree,
                              ldapData.Props.Distinct().ToArray(), cancellationToken, domain.Name,

--- a/src/Producers/LdapProducer.cs
+++ b/src/Producers/LdapProducer.cs
@@ -109,6 +109,8 @@ namespace Sharphound.Producers
                 if (!configurationNCsCollected.Contains(configAdsPath))
                 {
                     Context.Logger.LogInformation("Beginning LDAP search for {Domain} Configuration NC", domain.Name);
+                    // Ensure we only collect the Configuration NC once per forest
+                    configurationNCsCollected.Add(configAdsPath);
 
                     //Do a basic LDAP search and grab results
                     foreach (var searchResult in Context.LDAPUtils.QueryLDAP(configNcData.Filter.GetFilter(), SearchScope.Subtree,
@@ -119,9 +121,6 @@ namespace Sharphound.Producers
                         await Channel.Writer.WriteAsync(searchResult, cancellationToken);
                         Context.Logger.LogTrace("Producer wrote {DistinguishedName} to channel", searchResult.DistinguishedName);
                     }
-
-                    // Ensure we only collect the Configuration NC once per forest
-                    configurationNCsCollected.Add(configAdsPath);
                 }
                 else
                 {

--- a/src/Producers/LdapProducer.cs
+++ b/src/Producers/LdapProducer.cs
@@ -31,6 +31,11 @@ namespace Sharphound.Producers
             var log = Context.Logger;
             var utils = Context.LDAPUtils;
 
+            if (string.IsNullOrEmpty(ldapData.Filter.GetFilter()))
+            {
+                return;
+            }
+
             if (Context.Flags.CollectAllProperties)
             {
                 log.LogDebug("CollectAllProperties set. Changing LDAP properties to *");
@@ -83,7 +88,6 @@ namespace Sharphound.Producers
                     Context.Logger.LogTrace("Producer wrote {DistinguishedName} to channel", searchResult.DistinguishedName);
                 }
             }
-
         }
 
         /// <summary>

--- a/src/Producers/LdapProducer.cs
+++ b/src/Producers/LdapProducer.cs
@@ -76,7 +76,7 @@ namespace Sharphound.Producers
                 foreach (var searchResult in Context.LDAPUtils.QueryLDAP(ldapData.Filter.GetFilter(), SearchScope.Subtree,
                              ldapData.Props.Distinct().ToArray(), cancellationToken, domain.Name,
                              adsPath: Context.SearchBase,
-                             includeAcl: (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.ACL) != 0 || (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.CertServices) != 0))
+                             includeAcl: (Context.ResolvedCollectionMethods & ResolvedCollectionMethod.ACL) != 0))
                 {
                     var l = searchResult.DistinguishedName.ToLower();
                     if (l.Contains("cn=domainupdates,cn=system"))

--- a/src/Runtime/CollectionTask.cs
+++ b/src/Runtime/CollectionTask.cs
@@ -84,17 +84,15 @@ namespace Sharphound.Runtime
 
             foreach (var wkp in _context.LDAPUtils.GetWellKnownPrincipalOutput(_context.DomainName))
             {
-                if (wkp.ObjectIdentifier.EndsWith(EnterpriseDCSuffix))
-                {
-                    if (wkp is Group g && g.Members.Length == 0)
-                    {
-                        continue;
-                    }
-                }
-                else
+                if (!wkp.ObjectIdentifier.EndsWith(EnterpriseDCSuffix))
                 {
                     wkp.Properties["reconcile"] = false;
                 }
+                else if (wkp is Group g && g.Members.Length == 0)
+                {
+                    continue;
+                }
+
                 await _outputChannel.Writer.WriteAsync(wkp);
             }
                 

--- a/src/Runtime/CollectionTask.cs
+++ b/src/Runtime/CollectionTask.cs
@@ -22,6 +22,7 @@ namespace Sharphound.Runtime
         private readonly OutputWriter _outputWriter;
         private readonly BaseProducer _producer;
         private readonly List<Task> _taskPool = new();
+        private const string EnterpriseDCSuffix = "S-1-5-9";
 
         public CollectionTask(IContext context)
         {
@@ -82,7 +83,21 @@ namespace Sharphound.Runtime
             _log.LogInformation("Consumers finished, closing output channel");
 
             foreach (var wkp in _context.LDAPUtils.GetWellKnownPrincipalOutput(_context.DomainName))
+            {
+                if (wkp.ObjectIdentifier.EndsWith(EnterpriseDCSuffix))
+                {
+                    if (wkp is Group g && g.Members.Length == 0)
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    wkp.Properties["reconcile"] = false;
+                }
                 await _outputChannel.Writer.WriteAsync(wkp);
+            }
+                
 
             _outputChannel.Writer.Complete();
             _compStatusChannel?.Writer.Complete();

--- a/src/Runtime/LDAPConsumer.cs
+++ b/src/Runtime/LDAPConsumer.cs
@@ -37,6 +37,11 @@ namespace Sharphound.Runtime
                         watch.Elapsed.TotalMilliseconds, res.DisplayName);
                     if (processed == null)
                         continue;
+
+                    if (processed is Domain d && context.CollectedDomainSids.Contains(d.ObjectIdentifier))
+                    {
+                        d.Properties.Add("collected", true);
+                    }
                     await outputChannel.Writer.WriteAsync(processed);
                 }
                 catch (Exception e)

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -619,7 +619,9 @@ namespace Sharphound.Runtime
                 ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
             }
 
-            // Collect properties from CA server registry
+            if ((_methods & ResolvedCollectionMethod.CARegistry) != 0)
+            {
+                 // Collect properties from CA server registry
             var cASecurityCollected = false;
             var enrollmentAgentRestrictionsCollected = false;
             var isUserSpecifiesSanEnabledCollected = false;
@@ -648,7 +650,8 @@ namespace Sharphound.Runtime
             ret.Properties.Add("casecuritycollected", cASecurityCollected);
             ret.Properties.Add("enrollmentagentrestrictionscollected", enrollmentAgentRestrictionsCollected);
             ret.Properties.Add("isuserspecifiessanenabledcollected", isUserSpecifiesSanEnabledCollected);
-
+            }
+            
             return ret;
         }
 

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -498,10 +498,10 @@ namespace Sharphound.Runtime
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
 
-            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            if ((_methods & ResolvedCollectionMethod.Container) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
                 ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
 
-            if ((_methods & ResolvedCollectionMethod.ACL) != 0)
+            if ((_methods & ResolvedCollectionMethod.ACL) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.Aces = _aclProcessor.ProcessACL(resolvedSearchResult, entry)
                     .ToArray();
@@ -509,7 +509,7 @@ namespace Sharphound.Runtime
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
 
-            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0)
+            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 if (_context.Flags.CollectAllProperties)
                 {

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -226,6 +226,7 @@ namespace Sharphound.Runtime
             {
                 await compStatusChannel.Writer.WriteAsync(availability.GetCSVStatus(resolvedSearchResult.DisplayName),
                     _cancellationToken);
+                ret.Status = availability;
                 return ret;
             }
 

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -561,21 +561,22 @@ namespace Sharphound.Runtime
             ret.Properties.Add("name", resolvedSearchResult.DisplayName);
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
+            
 
-            if ((_methods & ResolvedCollectionMethod.ACL) != 0)
+            if ((_methods & ResolvedCollectionMethod.ACL) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.Aces = _aclProcessor.ProcessACL(resolvedSearchResult, entry).ToArray();
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
 
-            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0)
+            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 var props = LDAPPropertyProcessor.ReadRootCAProperties(entry);
                 ret.Properties.Merge(props);
             }
 
-            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            if ((_methods & ResolvedCollectionMethod.Container) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
             }
@@ -595,20 +596,20 @@ namespace Sharphound.Runtime
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
 
-            if ((_methods & ResolvedCollectionMethod.ACL) != 0)
+            if ((_methods & ResolvedCollectionMethod.ACL) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.Aces = _aclProcessor.ProcessACL(resolvedSearchResult, entry).ToArray();
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
 
-            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0)
+            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 var props = LDAPPropertyProcessor.ReadAIACAProperties(entry);
                 ret.Properties.Merge(props);
             }
 
-            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            if ((_methods & ResolvedCollectionMethod.Container) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
             }
@@ -628,14 +629,14 @@ namespace Sharphound.Runtime
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
 
-            if ((_methods & ResolvedCollectionMethod.ACL) != 0)
+            if ((_methods & ResolvedCollectionMethod.ACL) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.Aces = _aclProcessor.ProcessACL(resolvedSearchResult, entry).ToArray();
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
 
-            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0)
+            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 var props = LDAPPropertyProcessor.ReadEnterpriseCAProperties(entry);
                 ret.Properties.Merge(props);
@@ -644,15 +645,15 @@ namespace Sharphound.Runtime
                 ret.EnabledCertTemplates = _certAbuseProcessor.ProcessCertTemplates(entry.GetArrayProperty(LDAPProperties.CertificateTemplates), resolvedSearchResult.Domain).ToArray();
             }
 
-            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            if ((_methods & ResolvedCollectionMethod.Container) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
             }
 
             // Collect properties from CA server registry
-            bool cASecurityCollected = false;
-            bool enrollmentAgentRestrictionsCollected = false;
-            bool isUserSpecifiesSanEnabledCollected = false;
+            var cASecurityCollected = false;
+            var enrollmentAgentRestrictionsCollected = false;
+            var isUserSpecifiesSanEnabledCollected = false;
             var caName = entry.GetProperty(LDAPProperties.Name);
             var dnsHostName = entry.GetProperty(LDAPProperties.DNSHostName);
             if ((_methods & ResolvedCollectionMethod.CARegistry) != 0 && caName != null && dnsHostName != null)
@@ -695,14 +696,14 @@ namespace Sharphound.Runtime
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
 
-            if ((_methods & ResolvedCollectionMethod.ACL) != 0)
+            if ((_methods & ResolvedCollectionMethod.ACL) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.Aces = _aclProcessor.ProcessACL(resolvedSearchResult, entry).ToArray();
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
 
-            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0)
+            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 var props = LDAPPropertyProcessor.ReadNTAuthStoreProperties(entry);
 
@@ -715,7 +716,7 @@ namespace Sharphound.Runtime
                 ret.Properties.Merge(props);
             }
 
-            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            if ((_methods & ResolvedCollectionMethod.Container) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
             }
@@ -735,20 +736,20 @@ namespace Sharphound.Runtime
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
 
-            if ((_methods & ResolvedCollectionMethod.ACL) != 0)
+            if ((_methods & ResolvedCollectionMethod.ACL) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.Aces = _aclProcessor.ProcessACL(resolvedSearchResult, entry).ToArray();
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
 
-            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0)
+            if ((_methods & ResolvedCollectionMethod.ObjectProps) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 var certTemplatesProps = LDAPPropertyProcessor.ReadCertTemplateProperties(entry);
                 ret.Properties.Merge(certTemplatesProps);
             }
 
-            if ((_methods & ResolvedCollectionMethod.Container) != 0)
+            if ((_methods & ResolvedCollectionMethod.Container) != 0 || (_methods & ResolvedCollectionMethod.CertServices) != 0)
             {
                 ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);
             }

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -108,7 +108,6 @@ namespace Sharphound.Runtime
             ret.Properties.Add("name", resolvedSearchResult.DisplayName);
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
-            ret.Properties.Add("highvalue", false);
             ret.Properties.Add("samaccountname", entry.GetProperty(LDAPProperties.SAMAccountName));
 
             if ((_methods & ResolvedCollectionMethod.ACL) != 0)
@@ -172,7 +171,6 @@ namespace Sharphound.Runtime
             ret.Properties.Add("name", resolvedSearchResult.DisplayName);
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
-            ret.Properties.Add("highvalue", false);
             ret.Properties.Add("samaccountname", entry.GetProperty(LDAPProperties.SAMAccountName));
 
             var hasLaps = entry.HasLAPS();
@@ -322,7 +320,6 @@ namespace Sharphound.Runtime
             ret.Properties.Add("name", resolvedSearchResult.DisplayName);
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
-            ret.Properties.Add("highvalue", IsHighValueGroup(resolvedSearchResult.ObjectId));
             ret.Properties.Add("samaccountname", entry.GetProperty(LDAPProperties.SAMAccountName));
 
             if ((_methods & ResolvedCollectionMethod.ACL) != 0)
@@ -356,30 +353,6 @@ namespace Sharphound.Runtime
             return ret;
         }
 
-        private bool IsHighValueGroup(string objectId)
-        {
-            // TODO: replace w/ a more definitive/centralized list
-            var suffixes = new string[]
-            {
-                "-512",
-                "-516",
-                "-519",
-                "S-1-5-32-544",
-                "S-1-5-32-548",
-                "S-1-5-32-549",
-                "S-1-5-32-550",
-                "S-1-5-32-551",
-            };
-            foreach (var suffix in suffixes)
-            {
-                if (objectId.EndsWith(suffix))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         private async Task<Domain> ProcessDomainObject(ISearchResultEntry entry,
             ResolvedSearchResult resolvedSearchResult)
         {
@@ -392,7 +365,6 @@ namespace Sharphound.Runtime
             ret.Properties.Add("name", resolvedSearchResult.DisplayName);
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
-            ret.Properties.Add("highvalue", true);
 
             if ((_methods & ResolvedCollectionMethod.ACL) != 0)
             {
@@ -440,7 +412,6 @@ namespace Sharphound.Runtime
             ret.Properties.Add("name", resolvedSearchResult.DisplayName);
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
-            ret.Properties.Add("highvalue", false);
 
             if ((_methods & ResolvedCollectionMethod.ACL) != 0)
             {
@@ -474,7 +445,6 @@ namespace Sharphound.Runtime
             ret.Properties.Add("name", resolvedSearchResult.DisplayName);
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
-            ret.Properties.Add("highvalue", false);
 
             if ((_methods & ResolvedCollectionMethod.ACL) != 0)
             {
@@ -522,7 +492,6 @@ namespace Sharphound.Runtime
             ret.Properties.Add("name", resolvedSearchResult.DisplayName);
             ret.Properties.Add("distinguishedname", entry.DistinguishedName.ToUpper());
             ret.Properties.Add("domainsid", resolvedSearchResult.DomainSid);
-            ret.Properties.Add("highvalue", false);
 
             if ((_methods & ResolvedCollectionMethod.Container) != 0)
                 ret.ContainedBy = _containerProcessor.GetContainingObject(entry.DistinguishedName);


### PR DESCRIPTION
When collecting adcs, we were sending unexpected data due to a mismatch between collection method set and actual data collected. This also fixes several small inconsistencies in data