### PR TITLE
Toss out CAs processed without SIDs

### DIFF
--- a/src/Producers/ComputerFileProducer.cs
+++ b/src/Producers/ComputerFileProducer.cs
@@ -46,7 +46,7 @@ namespace Sharphound.Producers
                     string sid;
                     if (!computer.StartsWith("S-1-5-21"))
                         //The computer isn't a SID so try to convert it to one
-                        sid = await Context.LDAPUtils.ResolveHostToSid(computer, Context.DomainName);
+                        sid = await Context.LDAPUtils.ResolveHostToSidWithHostnameFallback(computer, Context.DomainName);
                     else
                         //The computer is already a sid, so just store it off
                         sid = computer;

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -638,6 +638,13 @@ namespace Sharphound.Runtime
                 {
                     ret.HostingComputer = await _context.LDAPUtils.ResolveHostToSid(dnsHostName, resolvedSearchResult.Domain);
 
+                    // If we don't resolve a SID to this CA, throw it out
+                    if (ret.HostingComputer == null)
+                    {
+                        _log.LogWarning("Unable to resolve Enterprise CA host to SID.", dnsHostName, resolvedSearchResult.Domain);
+                        return null;
+                    }
+
                     CARegistryData cARegistryData = new()
                     {
                         IsUserSpecifiesSanEnabled = _certAbuseProcessor.IsUserSpecifiesSanEnabled(dnsHostName, caName),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Pairs with https://github.com/BloodHoundAD/SharpHoundCommon/pull/108
When no SID is resolved for a CA we don't want to process the edge or node.  Currently SharpHoundCommon has a hostname fallback, where if a SID cannot be resolved a hostname is returned instead, and so for CAs that can't be found in LDAP we still process them as "no name" domain objects if they exist in the DNS.  We want instead to throw these nodes/edges out if they can't be queried by LDAP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-4206

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My changes include a database migration.