### PR TITLE
Skip over CAs that can't be resolved to SIDs during collection

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -638,11 +638,11 @@ namespace Sharphound.Runtime
                 {
                     ret.HostingComputer = await _context.LDAPUtils.ResolveHostToSid(dnsHostName, resolvedSearchResult.Domain);
 
-                    // If ResolveHostToSid does not return a valid SID, we don't want to process this CA
-                    if (ret.HostingComputer == null || !ret.HostingComputer.StartsWith("S-1-"))
+                    // If ResolveHostToSid does not return a valid SID, we don't want to record this host
+                    if (ret.HostingComputer != null && !ret.HostingComputer.StartsWith("S-1-"))
                     {
-                        _log.LogWarning("CA could not be resolved to a SID, skipping.", dnsHostName, resolvedSearchResult.Domain);
-                        return null;
+                        _log.LogWarning("CA host could not be resolved to a SID.", dnsHostName, resolvedSearchResult.Domain);
+                        ret.HostingComputer = null;
                     }
 
                     CARegistryData cARegistryData = new()

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -638,6 +638,13 @@ namespace Sharphound.Runtime
                 {
                     ret.HostingComputer = await _context.LDAPUtils.ResolveHostToSid(dnsHostName, resolvedSearchResult.Domain);
 
+                    // If ResolveHostToSid does not return a valid SID, we don't want to process this CA
+                    if (ret.HostingComputer == null || !ret.HostingComputer.StartsWith("S-1-"))
+                    {
+                        _log.LogWarning("CA could not be resolved to a SID, skipping.", dnsHostName, resolvedSearchResult.Domain);
+                        return null;
+                    }
+
                     CARegistryData cARegistryData = new()
                     {
                         IsUserSpecifiesSanEnabled = _certAbuseProcessor.IsUserSpecifiesSanEnabled(dnsHostName, caName),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
If `ResolveHostToSid` doesn't return a valid SID when processing a CA, we don't want to collect it.
Currently `ResolveHostToSid` from SHCommon falls back onto a hostname from DNS when a SID can't be determined.  For now we wish to leave that behavior as is.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BP-508

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes include a database migration.