### PR TITLE
[BED-4074] Exit SharpHound if SharpHoundRPC.dll not found

### DIFF
--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -534,6 +534,13 @@ namespace Sharphound
                         return;
                     context = links.SetSessionUserName(options.OverrideUserName, context);
                     context = links.InitCommonLib(context);
+
+                    if (!File.Exists("SharpHoundRPC.dll"))
+                    {
+                        logger.LogCritical("SharpHoundRPC.dll not found. Please reinstall SharpHound and try again.");
+                        return;
+                    }
+
                     context = links.GetDomainsForEnumeration(context);
                     if (context.Flags.IsFaulted)
                         return;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Exit SharpHound at startup if CommonLib is missing SharpHoundRPC.dll

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BP-316

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
