### PR TITLE
Chore: Change PowerShell docs LDAPS default port from 686 to 636 to remove typo

### DIFF
--- a/src/PowerShell/Template.ps1
+++ b/src/PowerShell/Template.ps1
@@ -126,7 +126,7 @@
 
     .PARAMETER LdapPort
 
-        Port LDAP is running on. Defaults to 389/686 for LDAPS
+        Port LDAP is running on. Defaults to 389/636 for LDAPS
 
     .PARAMETER SecureLDAP
 


### PR DESCRIPTION
## Description

Correct a typo in the PowerShell template. 636 is the default port used for LDAPS, not 686. This is true in IANA port assignments and the current behaviour of Sharphound collector and the targeted Windows operating systems.

## Motivation and Context

Correct documentation to avoid readers becoming confused.

## How Has This Been Tested?

This is a single character change to a documentation comment. Program functionality is not altered.
Use of Wireshark and reading of documentation and code confirmed that port 686 was not used but the IANA registered port for LDAPS (port 636) was.
https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=ldap

## Screenshots (if appropriate):

N/A

## Types of changes

-   [x] Chore (a change that does not modify the application functionality)
-   [] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.

I spotted a typo in a documentation comment while targeting an environment with LDAPS and thought I should submit a change. Happy to do additional work should this change require it.
