### PR TITLE
feat: collect ECA RoleSeparation

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -634,6 +634,7 @@ namespace Sharphound.Runtime
                 var cASecurityCollected = false;
                 var enrollmentAgentRestrictionsCollected = false;
                 var isUserSpecifiesSanEnabledCollected = false;
+                var roleSeparationEnabledCollected = false;
                 var caName = entry.GetProperty(LDAPProperties.Name);
                 var dnsHostName = entry.GetProperty(LDAPProperties.DNSHostName);
                 if ((_methods & ResolvedCollectionMethod.CARegistry) != 0 && caName != null && dnsHostName != null)
@@ -650,6 +651,7 @@ namespace Sharphound.Runtime
                     CARegistryData cARegistryData = new()
                     {
                         IsUserSpecifiesSanEnabled = _certAbuseProcessor.IsUserSpecifiesSanEnabled(dnsHostName, caName),
+                        RoleSeparationEnabled = _certAbuseProcessor.RoleSeparationEnabled(dnsHostName, caName),
                         EnrollmentAgentRestrictions = await _certAbuseProcessor.ProcessEAPermissions(caName, resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer),
 
                         // The CASecurity exist in the AD object DACL and in registry of the CA server. We prefer to use the values from registry as they are the ground truth.
@@ -660,12 +662,14 @@ namespace Sharphound.Runtime
                     cASecurityCollected = cARegistryData.CASecurity.Collected;
                     enrollmentAgentRestrictionsCollected = cARegistryData.EnrollmentAgentRestrictions.Collected;
                     isUserSpecifiesSanEnabledCollected = cARegistryData.IsUserSpecifiesSanEnabled.Collected;
+                    roleSeparationEnabledCollected = cARegistryData.RoleSeparationEnabled.Collected;
                     ret.CARegistryData = cARegistryData;
                 }
 
                 ret.Properties.Add("casecuritycollected", cASecurityCollected);
                 ret.Properties.Add("enrollmentagentrestrictionscollected", enrollmentAgentRestrictionsCollected);
                 ret.Properties.Add("isuserspecifiessanenabledcollected", isUserSpecifiesSanEnabledCollected);
+                ret.Properties.Add("roleseparationenabledcollected", roleSeparationEnabledCollected);
             }
             
             return ret;


### PR DESCRIPTION
## Description

Collection of enterpriseCA setting RoleSeparationEnabled

Ticket: BED-4351

<!--- Describe your changes in detail -->

Depends on this PR for commonlib: https://github.com/BloodHoundAD/SharpHoundCommon/pull/120

## Motivation and Context

If this setting is enabled, you cannot perform any CA actions if you have both ManageCA and ManageCertificates permissions. Only CA admins can modify the setting.

We need it for the ESC7 implementation, as some attack narratives require both ManageCA and ManageCertificates and could therefore be blocked by this setting.

More info on the setting: [Q: How can I make sure that a given Windows account is assigned only](https://www.itprotoday.com/security/q-how-can-i-make-sure-given-windows-account-assigned-only-single-certification-authority-ca)

## How Has This Been Tested?

Collection in my lab:
[20240426013313_BloodHound.zip](https://github.com/BloodHoundAD/SharpHoundCommon/files/15128061/20240426013313_BloodHound.zip)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
