### PR TITLE
Version Bump + Default Port Scan Timeout Change

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -6,8 +6,8 @@
         <LangVersion>latest</LangVersion>
         <DebugType>full</DebugType>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>2.5.4</Version>
-        <FileVersion>2.5.4</FileVersion>
+        <Version>2.5.6</Version>
+        <FileVersion>2.5.6</FileVersion>
         <Company>SpecterOps</Company>
         <Product>SharpHound</Product>
         <AssemblyName>SharpHound</AssemblyName>
@@ -24,8 +24,8 @@
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="SharpHoundCommon" Version="4.0.4" />
-        <PackageReference Include="SharpHoundRPC" Version="4.0.4" />
+        <PackageReference Include="SharpHoundCommon" Version="4.0.5" />
+        <PackageReference Include="SharpHoundRPC" Version="4.0.5" />
         <PackageReference Include="SharpZipLib" Version="1.3.3" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -109,7 +109,7 @@ namespace Sharphound
         [Option(HelpText = "Skip checking if 445 is open", Default = false)]
         public bool SkipPortCheck { get; set; }
 
-        [Option(HelpText = "Timeout for port checks in milliseconds", Default = 500)]
+        [Option(HelpText = "Timeout for port checks in milliseconds", Default = 10000)]
         public int PortCheckTimeout { get; set; }
 
         [Option(HelpText = "Skip check for PwdLastSet when enumerating computers", Default = false)]

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -114,6 +114,8 @@ namespace Sharphound.Runtime {
 
             return props;
         }
+        
+        
 
         private async Task<User> ProcessUserObject(IDirectoryObject entry,
             ResolvedSearchResult resolvedSearchResult) {
@@ -315,7 +317,7 @@ namespace Sharphound.Runtime {
             ret.Properties.Add("samaccountname", entry.GetProperty(LDAPProperties.SAMAccountName));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                ret.Aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry).ToArrayAsync();
+                ret.Aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry).ToArrayAsync(cancellationToken: _cancellationToken);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -323,7 +325,7 @@ namespace Sharphound.Runtime {
             if ((_methods & CollectionMethod.Group) != 0)
                 ret.Members = await _groupProcessor
                     .ReadGroupMembers(resolvedSearchResult, entry)
-                    .ToArrayAsync();
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
 
             if ((_methods & CollectionMethod.ObjectProps) != 0) {
                 var groupProps = LdapPropertyProcessor.ReadGroupProperties(entry);
@@ -368,7 +370,7 @@ namespace Sharphound.Runtime {
                     .ToArrayAsync();
 
             if ((_methods & CollectionMethod.ObjectProps) != 0) {
-                ret.Properties = ContextUtils.Merge(ret.Properties, LdapPropertyProcessor.ReadDomainProperties(entry));
+                ret.Properties = ContextUtils.Merge(ret.Properties, await _ldapPropertyProcessor.ReadDomainProperties(entry, resolvedSearchResult.Domain));
                 if (_context.Flags.CollectAllProperties) {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);


### PR DESCRIPTION
## Description
Bumps commonlib with new fixes

Ups our default port scan timeout to 10000ms. During testing we discovered that the task scheduler is not "fair" and can often result in false positives in the port scanner if set lower.
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
