### PR TITLE
Prep for CoerceToTGT

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -6,8 +6,8 @@
         <LangVersion>latest</LangVersion>
         <DebugType>full</DebugType>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>2.5.7</Version>
-        <FileVersion>2.5.7</FileVersion>
+        <Version>2.5.8</Version>
+        <FileVersion>2.5.8</FileVersion>
         <Company>SpecterOps</Company>
         <Product>SharpHound</Product>
         <AssemblyName>SharpHound</AssemblyName>
@@ -24,8 +24,8 @@
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="SharpHoundCommon" Version="4.0.7" />
-        <PackageReference Include="SharpHoundRPC" Version="4.0.7" />
+        <PackageReference Include="SharpHoundCommon" Version="4.0.8" />
+        <PackageReference Include="SharpHoundRPC" Version="4.0.8" />
         <PackageReference Include="SharpZipLib" Version="1.3.3" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -127,6 +127,7 @@ namespace Sharphound.Runtime {
             ret.Properties.Add("samaccountname", entry.GetProperty(LDAPProperties.SAMAccountName));
             if (entry.IsMSA()) ret.Properties.Add("msa", true);
             if (entry.IsGMSA()) ret.Properties.Add("gmsa", true);
+            ret.DomainSID = resolvedSearchResult.DomainSid;
 
             if ((_methods & CollectionMethod.ACL) != 0) {
                 var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry)
@@ -153,6 +154,7 @@ namespace Sharphound.Runtime {
 
                 ret.HasSIDHistory = userProps.SidHistory;
                 ret.AllowedToDelegate = userProps.AllowedToDelegate;
+                ret.UnconstrainedDelegation = userProps.UnconstrainedDelegation;
             }
 
             if ((_methods & CollectionMethod.SPNTargets) != 0) {
@@ -207,6 +209,7 @@ namespace Sharphound.Runtime {
                 ret.AllowedToAct = computerProps.AllowedToAct;
                 ret.HasSIDHistory = computerProps.SidHistory;
                 ret.DumpSMSAPassword = computerProps.DumpSMSAPassword;
+                ret.UnconstrainedDelegation = computerProps.UnconstrainedDelegation;
             }
 
             if ((_methods & CollectionMethod.Container) != 0) {


### PR DESCRIPTION
## Description

Add the UnconstrainedDelegation and DomainSID as properties outside the Properties output object for users and computers.

## Motivation and Context

Depends on this PR for Commonlib: https://github.com/BloodHoundAD/SharpHoundCommon/pull/171

This is required for the CoerceToTGT edge - a new traversable edge from computers and users configured with unconstrained delegation to the domain.

Ticket: BP-982

## How Has This Been Tested?

Collected in my lab: 
[20241016080901_BloodHound.zip](https://github.com/user-attachments/files/17398017/20241016080901_BloodHound.zip)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.