### PR TITLE
BED-4965 - Owns/Owner Rework

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -131,7 +131,8 @@ namespace Sharphound.Runtime {
             ret.DomainSID = resolvedSearchResult.DomainSid;
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (var aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (var aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 var gmsa = entry.GetByteProperty(LDAPProperties.GroupMSAMembership);
                 ret.Aces = aces.Concat(await _aclProcessor.ProcessGMSAReaders(gmsa, resolvedSearchResult.Domain)
                     .ToArrayAsync(cancellationToken: _cancellationToken)).ToArray();
@@ -187,7 +188,8 @@ namespace Sharphound.Runtime {
             ret.DomainSID = resolvedSearchResult.DomainSid;
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -320,7 +322,8 @@ namespace Sharphound.Runtime {
             ret.Properties.Add("samaccountname", entry.GetProperty(LDAPProperties.SAMAccountName));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -362,7 +365,8 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
                 ret.InheritanceHashes = _aclProcessor.GetInheritedAceHashes(entry, resolvedSearchResult).ToArray();
@@ -400,7 +404,8 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -425,7 +430,8 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
                 ret.InheritanceHashes = _aclProcessor.GetInheritedAceHashes(entry, resolvedSearchResult).ToArray();
@@ -471,7 +477,8 @@ namespace Sharphound.Runtime {
                 }
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
                 ret.InheritanceHashes = _aclProcessor.GetInheritedAceHashes(entry, resolvedSearchResult).ToArray();
@@ -500,7 +507,8 @@ namespace Sharphound.Runtime {
 
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -527,7 +535,8 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -555,7 +564,8 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -633,7 +643,8 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -668,7 +679,8 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -696,7 +708,8 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, ret.DoesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Configuration;
 using System.Runtime.Remoting;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -131,8 +132,9 @@ namespace Sharphound.Runtime {
             ret.DomainSID = resolvedSearchResult.DomainSid;
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (var aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (var aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 var gmsa = entry.GetByteProperty(LDAPProperties.GroupMSAMembership);
                 ret.Aces = aces.Concat(await _aclProcessor.ProcessGMSAReaders(gmsa, resolvedSearchResult.Domain)
                     .ToArrayAsync(cancellationToken: _cancellationToken)).ToArray();
@@ -188,8 +190,9 @@ namespace Sharphound.Runtime {
             ret.DomainSID = resolvedSearchResult.DomainSid;
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -322,8 +325,9 @@ namespace Sharphound.Runtime {
             ret.Properties.Add("samaccountname", entry.GetProperty(LDAPProperties.SAMAccountName));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -365,8 +369,9 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
                 ret.InheritanceHashes = _aclProcessor.GetInheritedAceHashes(entry, resolvedSearchResult).ToArray();
@@ -404,8 +409,9 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -430,8 +436,9 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
                 ret.InheritanceHashes = _aclProcessor.GetInheritedAceHashes(entry, resolvedSearchResult).ToArray();
@@ -477,8 +484,9 @@ namespace Sharphound.Runtime {
                 }
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
                 ret.InheritanceHashes = _aclProcessor.GetInheritedAceHashes(entry, resolvedSearchResult).ToArray();
@@ -507,8 +515,9 @@ namespace Sharphound.Runtime {
 
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -535,8 +544,9 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -564,8 +574,9 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -643,8 +654,9 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -679,8 +691,9 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
@@ -708,8 +721,9 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
-                (ret.Aces, bool doesAnyAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
+                (ret.Aces, bool doesAnyAceGrantOwnerRights, bool doesAnyInheritedAceGrantOwnerRights) = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
                 ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }


### PR DESCRIPTION
## Description

Updated SharpHound to collect two new properties for every domain object:
- DoesAnyAceGrantOwnerRights
- DoesAnyInheritedAceGrantOwnerRights


## Motivation and Context

https://specterops.atlassian.net/browse/BED-4965

During ingest, BloodHound will use this information to determine whether any benign, non-abusable ACEs granted permissions to the OWNER RIGHTS SID (S-1-3-4), and whether or not any such ACEs were inherited. These properties allow ingest to determine whether any Owns and WriteOwner permissions granted are abusable or not.

## How Has This Been Tested?

Please refer to https://specterops.atlassian.net/wiki/spaces/BE/pages/750157858/Owns+WriteOwner for detailed testing information.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
