### PR TITLE
chore: bump SharpHoundRPC version

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="SharpHoundCommon" Version="4.0.9" />
-        <PackageReference Include="SharpHoundRPC" Version="4.0.8" />
+        <PackageReference Include="SharpHoundRPC" Version="4.0.9" />
         <PackageReference Include="SharpZipLib" Version="1.3.3" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />


### PR DESCRIPTION
## Description

Updates the SharpHoundRPC package reference from `4.0.8` to `4.0.9` to match the SharpHoundCommon version bump introduced in commit https://github.com/BloodHoundAD/SharpHound/commit/64ef0e56661734566b8bd0fc58d59c44c645c7fa.

## Motivation and Context

Fixes the issue described here: https://github.com/BloodHoundAD/SharpHound/issues/125

## How Has This Been Tested?
I have not done extensive testing as this was a fairly minor change that should not affect anything as noted in the original issue.

## Types of changes

-   [X] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
