### PR TITLE
add support for env credentials or loading creds from json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ The listing below details the CLI arguments SharpHound supports. Additional deta
 
   --ldappassword             Password for LDAP
 
+  --ldapenvusername          Username for LDAP stored in a defined environment variable (argument takes the environment variable as input)
+
+  --ldapenvpassword          Password for LDAP stored in a defined environment variable (argument takes the environment variable as input)
+
+  --ldapcredentialsjsonpath  Path argument for a json file containing {"Username": "xxxx", "Password": "xxxx"} to be used instead of --ldapusername and --ldappassword
+
   --domaincontroller         Override domain controller to pull LDAP from. This option can result in data loss
 
   --ldapport                 (Default: 0) Override port for LDAP

--- a/src/JsonExtensions.cs
+++ b/src/JsonExtensions.cs
@@ -8,6 +8,12 @@ using SharpHoundCommonLib.Enums;
 
 namespace Sharphound
 {
+
+    public class Credentials
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
     public class CacheContractResolver : DefaultContractResolver
     {
         private static readonly CacheContractResolver Instance = new();

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -78,6 +78,15 @@ namespace Sharphound
         [Option(HelpText = "Password for LDAP", Default = null)]
         public string LDAPPassword { get; set; }
 
+        [Option(HelpText = "Path to Json file containing username/password", Default = null)]
+        public string LDAPCredentialJsonPath { get; set; }
+
+        [Option(HelpText = "Enviroment variable name for LDAP Username", Default = null)]
+        public string LDAPEnvUsername { get; set; }
+
+        [Option(HelpText = "Enviroment variable name for LDAP Password", Default = null)]
+        public string LDAPEnvPassword { get; set; }
+
         [Option(HelpText = "Do the session enumeration with local admin credentials instead of domain credentials", Default = false)]
         public bool DoLocalAdminSessionEnum { get; set; }
 

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -451,6 +451,26 @@ namespace Sharphound {
 
                     if (options.DomainController != null) ldapOptions.Server = options.DomainController;
 
+                    if (options.LDAPCredentialJsonPath != null) {
+                        string json = File.ReadAllText(options.LDAPCredentialJsonPath);
+                        Credentials ldapCreds = JsonConvert.DeserializeObject<Credentials>(json);
+                        ldapOptions.Username = ldapCreds.Username;
+                        ldapOptions.Password = ldapCreds.Password;
+                    }
+                    
+                    if (options.LDAPEnvUsername != null) {
+                        if (options.LDAPEnvPassword == null) {
+                            logger.LogError("You must specify LDAPEnvPassword if using the LDAPEnvUsername options");
+                            return;
+                        }
+
+                        string EnvUsername = Environment.GetEnvironmentVariable(options.LDAPEnvUsername);
+                        string EnvPassword = Environment.GetEnvironmentVariable(options.LDAPEnvPassword);
+
+                        ldapOptions.Username = EnvUsername;
+                        ldapOptions.Password = EnvPassword;
+                    }
+
                     if (options.LDAPUsername != null) {
                         if (options.LDAPPassword == null) {
                             logger.LogError("You must specify LDAPPassword if using the LDAPUsername options");


### PR DESCRIPTION
## Description

Add argument option to load ldapusername/ldappassword from environment variable (operator define the env variable name to pull from) or a operator defineable json file. I've specifically left out any configuration options or similar as it probably goes to much in conflict with the enterprise version of Sharphound

## Motivation and Context

I am not a big fan of spraying passwords in my windows logs. This should hopefully to some extent mitigate that. Do note that this is not to be looked at as a security feature, but it atleast prevents the host from spraying passwords into logs and collected logs. 

## How Has This Been Tested?

Compiled code, tested with json file and envoptions (also tested the --ldapusername --ldappassword options). 
This was tested on 4 different active directory domains. The changes are not huge and didnt impact any of the operations of Sharphound. 


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.

Didnt know there were any tests or where to define them. Im not doing anything towards the database, so that shouldnt be needed to define. Not sure if there are any other places than the readme to update

Im by no means of the imagination a developer, but it would be nice to have this or some similar feature included to ensure that passwords are not sprayed in the logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three CLI options to provide LDAP credentials: load from a JSON file or supply username/password via environment variables; credential sources are tried in a defined order.
  * Validation added to ensure paired environment credentials are present and to surface missing-password errors.

* **Documentation**
  * README updated with the new CLI credential options and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->