### PR TITLE
fix: BED-5058 have properties that are always added to EnterpriseCA objects

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -554,6 +554,15 @@ namespace Sharphound.Runtime {
             };
 
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
+            
+            // BED-5058: casecuritycollected, enrollmentagentrestrictionscollected, isuserspecifiessanenabledcollected,
+            // roleseparationenabledcollected properties should always be present under EnterpriseCA objects.
+            // Default value is false
+            // Collect properties from CA server registry
+            var cASecurityCollected = false;
+            var enrollmentAgentRestrictionsCollected = false;
+            var isUserSpecifiesSanEnabledCollected = false;
+            var roleSeparationEnabledCollected = false;
 
             if ((_methods & CollectionMethod.ACL) != 0 || (_methods & CollectionMethod.CertServices) != 0) {
                 ret.Aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry).ToArrayAsync();
@@ -581,11 +590,6 @@ namespace Sharphound.Runtime {
             }
 
             if ((_methods & CollectionMethod.CARegistry) != 0) {
-                // Collect properties from CA server registry
-                var cASecurityCollected = false;
-                var enrollmentAgentRestrictionsCollected = false;
-                var isUserSpecifiesSanEnabledCollected = false;
-                var roleSeparationEnabledCollected = false;
                 var caName = entry.GetProperty(LDAPProperties.Name);
                 var dnsHostName = entry.GetProperty(LDAPProperties.DNSHostName);
                 if (caName != null && dnsHostName != null) {
@@ -614,12 +618,12 @@ namespace Sharphound.Runtime {
                     roleSeparationEnabledCollected = cARegistryData.RoleSeparationEnabled.Collected;
                     ret.CARegistryData = cARegistryData;
                 }
-
-                ret.Properties.Add("casecuritycollected", cASecurityCollected);
-                ret.Properties.Add("enrollmentagentrestrictionscollected", enrollmentAgentRestrictionsCollected);
-                ret.Properties.Add("isuserspecifiessanenabledcollected", isUserSpecifiesSanEnabledCollected);
-                ret.Properties.Add("roleseparationenabledcollected", roleSeparationEnabledCollected);
             }
+            
+            ret.Properties.Add("casecuritycollected", cASecurityCollected);
+            ret.Properties.Add("enrollmentagentrestrictionscollected", enrollmentAgentRestrictionsCollected);
+            ret.Properties.Add("isuserspecifiessanenabledcollected", isUserSpecifiesSanEnabledCollected);
+            ret.Properties.Add("roleseparationenabledcollected", roleSeparationEnabledCollected);
 
             return ret;
         }


### PR DESCRIPTION
## Description

casecuritycollected, enrollmentagentrestrictionscollected, isuserspecifiessanenabledcollected, and roleseparationenabledcollected properties are always added for EnterpriseCA objects. Default value is false.

## Motivation and Context

In post-processing function of ADCSESC3, an "CARegistry" collection is needed to create accurate ADCSESC3 edges. It checks if EnrollmentAgentRestrictionsCollected is true. This means that ADCSESC3 edges cannot be created unless CARegistry collection is performed.
https://specterops.atlassian.net/browse/BED-5058

## How Has This Been Tested?

Manually tested. 
Performed a CARegistry collection and casecuritycollected, enrollmentagentrestrictionscollected, isuserspecifiessanenabledcollected, and roleseparationenabledcollected were true.
Performed a CertServices collection after and casecuritycollected, enrollmentagentrestrictionscollected, isuserspecifiessanenabledcollected, and roleseparationenabledcollected were false.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
