### PR TITLE
HostsCAService edge not being generated fix

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -718,14 +718,12 @@ namespace Sharphound.Runtime {
                 var enrollmentAgentRestrictionsCollected = false;
                 var isUserSpecifiesSanEnabledCollected = false;
                 var roleSeparationEnabledCollected = false;
-                var hostingComputer = "";
                 var caName = entry.GetProperty(LDAPProperties.Name);
                 var dnsHostName = entry.GetProperty(LDAPProperties.DNSHostName);
                 if (caName != null && dnsHostName != null) {
-                    
                     if (await _context.LDAPUtils.ResolveHostToSid(dnsHostName, resolvedSearchResult.DomainSid) is
                             (true, var sid) && sid.StartsWith("S-1-")) {
-                        hostingComputer = sid;
+                        ret.HostingComputer = sid;
                     } else {
                         _log.LogWarning("CA {Name} host ({Dns}) could not be resolved to a SID.", caName, dnsHostName);
                     }
@@ -733,13 +731,13 @@ namespace Sharphound.Runtime {
                     CARegistryData cARegistryData = new() {
                         IsUserSpecifiesSanEnabled = _certAbuseProcessor.IsUserSpecifiesSanEnabled(dnsHostName, caName),
                         EnrollmentAgentRestrictions = await _certAbuseProcessor.ProcessEAPermissions(caName,
-                            resolvedSearchResult.Domain, dnsHostName, hostingComputer),
+                            resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer),
                         RoleSeparationEnabled = _certAbuseProcessor.RoleSeparationEnabled(dnsHostName, caName),
 
                         // The CASecurity exist in the AD object DACL and in registry of the CA server. We prefer to use the values from registry as they are the ground truth.
                         // If changes are made on the CA server, registry and the AD object is updated. If changes are made directly on the AD object, the CA server registry is not updated.
                         CASecurity = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(caName,
-                            resolvedSearchResult.Domain, dnsHostName, hostingComputer)
+                            resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer)
                     };
 
                     cASecurityCollected = cARegistryData.CASecurity.Collected;

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -698,6 +698,12 @@ namespace Sharphound.Runtime {
                 var dnsHostName = entry.GetProperty(LDAPProperties.DNSHostName);
 
                 if (caName != null && dnsHostName != null) {
+                    if (await _context.LDAPUtils.ResolveHostToSid(dnsHostName, resolvedSearchResult.DomainSid) is
+                            (true, var sid) && sid.StartsWith("S-1-")) {
+                        ret.HostingComputer = sid;
+                    } else {
+                        _log.LogWarning("CA {Name} host ({Dns}) could not be resolved to a SID.", caName, dnsHostName);
+                    }
                     var caEnrollmentProcessor = new CAEnrollmentProcessor(dnsHostName, caName, _log);
                     var ntlmEndpoints = await caEnrollmentProcessor.ScanAsync();
                     ret.HttpEnrollmentEndpoints = ntlmEndpoints.ToArray();
@@ -712,12 +718,14 @@ namespace Sharphound.Runtime {
                 var enrollmentAgentRestrictionsCollected = false;
                 var isUserSpecifiesSanEnabledCollected = false;
                 var roleSeparationEnabledCollected = false;
+                var hostingComputer = "";
                 var caName = entry.GetProperty(LDAPProperties.Name);
                 var dnsHostName = entry.GetProperty(LDAPProperties.DNSHostName);
                 if (caName != null && dnsHostName != null) {
+                    
                     if (await _context.LDAPUtils.ResolveHostToSid(dnsHostName, resolvedSearchResult.DomainSid) is
                             (true, var sid) && sid.StartsWith("S-1-")) {
-                        ret.HostingComputer = sid;
+                        hostingComputer = sid;
                     } else {
                         _log.LogWarning("CA {Name} host ({Dns}) could not be resolved to a SID.", caName, dnsHostName);
                     }
@@ -725,13 +733,13 @@ namespace Sharphound.Runtime {
                     CARegistryData cARegistryData = new() {
                         IsUserSpecifiesSanEnabled = _certAbuseProcessor.IsUserSpecifiesSanEnabled(dnsHostName, caName),
                         EnrollmentAgentRestrictions = await _certAbuseProcessor.ProcessEAPermissions(caName,
-                            resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer),
+                            resolvedSearchResult.Domain, dnsHostName, hostingComputer),
                         RoleSeparationEnabled = _certAbuseProcessor.RoleSeparationEnabled(dnsHostName, caName),
 
                         // The CASecurity exist in the AD object DACL and in registry of the CA server. We prefer to use the values from registry as they are the ground truth.
                         // If changes are made on the CA server, registry and the AD object is updated. If changes are made directly on the AD object, the CA server registry is not updated.
                         CASecurity = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(caName,
-                            resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer)
+                            resolvedSearchResult.Domain, dnsHostName, hostingComputer)
                     };
 
                     cASecurityCollected = cARegistryData.CASecurity.Collected;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add `HostingComputer` to CertServices collection

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-4957

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run CertServices collection.
2. See there is a `HostsCAService` edge present from a Computer node to an EnterpriseCA node when the EnterpriseCA property `dnshostname` matches the computer name of the Computer node.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.
