### PR TITLE
[BED-5936] - Check the Installed Version of .Net Framework Prior to Running

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -6,8 +6,8 @@
         <LangVersion>latest</LangVersion>
         <DebugType>full</DebugType>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>2.6.6</Version>
-        <FileVersion>2.6.6</FileVersion>
+        <Version>2.6.7</Version>
+        <FileVersion>2.6.7</FileVersion>
         <Company>SpecterOps</Company>
         <Product>SharpHound</Product>
         <AssemblyName>SharpHound</AssemblyName>

--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -6,8 +6,8 @@
         <LangVersion>latest</LangVersion>
         <DebugType>full</DebugType>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>2.6.7</Version>
-        <FileVersion>2.6.7</FileVersion>
+        <Version>2.6.6</Version>
+        <FileVersion>2.6.6</FileVersion>
         <Company>SpecterOps</Company>
         <Product>SharpHound</Product>
         <AssemblyName>SharpHound</AssemblyName>

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
 using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
 using Sharphound.Client;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Enums;
@@ -37,6 +38,17 @@ namespace Sharphound
         public static async Task Main(string[] args) {
             var logger = new BasicLogger((int)LogLevel.Information);
             logger.LogInformation("This version of SharpHound is compatible with the 5.0.0 Release of BloodHound");
+
+            // Checks the release version available on the machine.
+            var releaseVersion = (int) Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Release", 0);
+            if (releaseVersion == 0) releaseVersion = (int) Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Release", 0);
+            // The value 461808 corresponds to .Net 4.7.2
+            if (releaseVersion < 461808)
+            {
+                logger.LogError("The .Net Runtime is not compatible with SharpHound. Please update to .Net 4.7.2.");
+                return;
+            }
+
             try {
                 var parser = new Parser(with => {
                     with.CaseInsensitiveEnumValues = true;

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -39,17 +39,17 @@ namespace Sharphound
             var logger = new BasicLogger((int)LogLevel.Information);
             logger.LogInformation("This version of SharpHound is compatible with the 5.0.0 Release of BloodHound");
 
-            // Checks the release version available on the machine.
-            var releaseVersion = (int) Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Release", 0);
-            if (releaseVersion == 0) releaseVersion = (int) Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Release", 0);
-            // The value 461808 corresponds to .Net 4.7.2
-            if (releaseVersion < 461808)
-            {
-                logger.LogError("The .Net Runtime is not compatible with SharpHound. Please update to .Net 4.7.2.");
-                return;
-            }
-
             try {
+                // Checks the release version available on the machine.
+                var releaseVersion = (int) Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Release", 0);
+                if (releaseVersion == 0) releaseVersion = (int) Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Release", 0);
+                // The value 461808 corresponds to .Net 4.7.2
+                if (releaseVersion < 461808)
+                {
+                    logger.LogError("The .Net Runtime is not compatible with SharpHound. Please update to .Net 4.7.2.");
+                    return;
+                }
+
                 var parser = new Parser(with => {
                     with.CaseInsensitiveEnumValues = true;
                     with.CaseSensitive = false;


### PR DESCRIPTION
## Description

Updates to SharpHound to check the installed version of .Net Framework to ensure it meets our target. If the system does not, a log will be created and SharpHound will exit. 

## Motivation and Context

This PR addresses: [BED-5936](https://specterops.atlassian.net/browse/BED-5936)

This change was recommended because some users are on older versions of Windows which can cause issues while running the application since we target a newer version of .Net Framework.

## How Has This Been Tested?

This was tested by running SharpHound on a system with .Net Framework 4.7.2 and trying to run the software on a system with .Net  Framework 4.6.2. The software was unable to run on the latter system. This system was then updated by installing .Net Framework 4.7.2, which allowed SharpHound to run. 

In both the system that could initially run the updated application and the system that was updated to be able to run SharpHound, a collection was run and the data was successfully ingested in a local BloodHound Enterprise Instance. 

## Screenshots (optional):

### The new error log
![image](https://github.com/user-attachments/assets/4e28e6f4-8947-4879-95df-4b2431dca56d)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
  -  As a note, I could not find any documentation specifying the necessary version of .Net Framework on the system. Should there be place for this?
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-5936]: https://specterops.atlassian.net/browse/BED-5936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ