### PR TITLE
BED-5922 Update CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,16 +2,38 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created, edited]
+  pull_request_target:
+    types: [opened,closed,synchronize]
 
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
-      # Trigger the CLA assistant check when someone comments the specified text.
-      # The intent is to comment `@cla-pls` on PRs from external contributors to initiate the CLA check.
-      # The other strings that trigger the action are used in normal operation of the `contributor-assistant` action.
+      - name: "Organization Members"
+        id: org-members
+        run: |
+          ALL_MEMBERS=""
+          URL="${{ github.api_url }}/orgs/${{ github.repository_owner }}/members?per_page=100"
+
+          while [ -n "$URL" ]; do
+            MEMBERS=$(curl -s -D headers.txt -H "Authorization: Bearer ${{ secrets.READ_MEMBERS_SCOPE }}" "$URL" | jq -r '[.[] | .login] | join(",")')
+            URL=$(grep -i '^Link:' headers.txt | sed -n 's/.*<\(.*\)>; rel="next".*/\1/p' || true)
+            rm -f headers.txt
+
+            if [ -n "$MEMBERS" ]; then
+              if [ -z "$ALL_MEMBERS" ]; then
+                ALL_MEMBERS="$MEMBERS"
+              else
+                ALL_MEMBERS="$ALL_MEMBERS,$MEMBERS"
+              fi
+            fi
+          done
+
+          echo "::add-mask::$ALL_MEMBERS"
+          echo "org_members=$ALL_MEMBERS" >> $GITHUB_OUTPUT
+        
       - name: "CLA Assistant"
-        if: github.event.issue.pull_request && (github.event.comment.body == '@cla-pls' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA' || github.event.comment.body == 'recheck')
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -22,4 +44,4 @@ jobs:
           branch: "main"
           remote-organization-name: SpecterOps
           remote-repository-name: CLA
-
+          allowlist: ${{ steps.org-members.outputs.org_members }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,23 +1,25 @@
 name: "CLA Assistant"
 on:
   issue_comment:
-    types: [created]
-  pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [created, edited]
 
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
+      # Trigger the CLA assistant check when someone comments the specified text.
+      # The intent is to comment `@cla-pls` on PRs from external contributors to initiate the CLA check.
+      # The other strings that trigger the action are used in normal operation of the `contributor-assistant` action.
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: github.event.issue.pull_request && (github.event.comment.body == '@cla-pls' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA' || github.event.comment.body == 'recheck')
         uses: contributor-assistant/github-action@v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.REPO_SCOPE }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.REPO_SCOPE }}
         with:
-          path-to-signatures: 'signatures.json'
-          path-to-document: 'https://github.com/BloodHoundAD/CLA/blob/main/ICLA.md'
-          branch: 'main'
-          remote-organization-name: BloodHoundAD
-          remote-repository-name:  CLA
+          path-to-signatures: "signatures.json"
+          path-to-document: "https://github.com/SpecterOps/CLA/blob/main/ICLA.md"
+          branch: "main"
+          remote-organization-name: SpecterOps
+          remote-repository-name: CLA
+


### PR DESCRIPTION
## Description

This PR updates the CLA assistant GitHub Action with a couple changes:

- Update the location of the CLA and signatures list to point to a repo under the `SpecterOps` org
- Change the the CLA check to only occur for members outside of the `SpecterOps` org

The CLA check is now intended to be run only for contributors outside of the `SpecterOps` organization. This is implemented by a API lookup of all org members prior to running the CLA Assistant and adding them the to the whitelist parameter of the Action.

## Motivation and Context

Resolves BED-5922

*Why is this change required? What problem does it solve?*

The CLA repo is moving under the `SpecterOps` organization instead of the legacy `BloodHoundAD` org.

## How Has This Been Tested?

* Tested the action functions as expected on a separate test repo

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the CLA signing workflow to trigger on both created and edited issue comments with specific phrases.
  - Updated references and URLs from "BloodHoundAD" to "SpecterOps" in the CLA process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->