### PR TITLE
chore: Configure ProcessACL for async enumerable ACE collection

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Net;
-using System.Runtime.Remoting.Contexts;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Channels;
@@ -16,7 +13,6 @@ using SharpHoundCommonLib.DirectoryObjects;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
 using SharpHoundCommonLib.Processors;
-using SharpHoundRPC.PortScanner;
 using Container = SharpHoundCommonLib.OutputTypes.Container;
 using Group = SharpHoundCommonLib.OutputTypes.Group;
 using Label = SharpHoundCommonLib.Enums.Label;
@@ -139,10 +135,10 @@ namespace Sharphound.Runtime {
             ret.DomainSID = resolvedSearchResult.DomainSid;
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 var gmsa = entry.GetByteProperty(LDAPProperties.GroupMSAMembership);
                 ret.Aces = aces.Concat(await _aclProcessor.ProcessGMSAReaders(gmsa, resolvedSearchResult.Domain)
                     .ToArrayAsync(cancellationToken: _cancellationToken)).ToArray();
@@ -202,10 +198,10 @@ namespace Sharphound.Runtime {
             ret.DomainSID = resolvedSearchResult.DomainSid;
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -401,10 +397,10 @@ namespace Sharphound.Runtime {
             ret.Properties.Add("samaccountname", entry.GetProperty(LDAPProperties.SAMAccountName));
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -448,11 +444,10 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Aces = aces;
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
                 ret.InheritanceHashes = _aclProcessor.GetInheritedAceHashes(entry, resolvedSearchResult).ToArray();
@@ -491,10 +486,10 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -520,10 +515,10 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -570,10 +565,10 @@ namespace Sharphound.Runtime {
                 }
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -603,10 +598,10 @@ namespace Sharphound.Runtime {
 
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -634,10 +629,10 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -665,10 +660,10 @@ namespace Sharphound.Runtime {
             };
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -768,10 +763,10 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -807,10 +802,10 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
@@ -839,10 +834,10 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var (aces, doesAnyAceGrantOwnerRights, doesAnyInheritedAceGrantOwnerRights) =
-                    await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true);
-                ret.Properties.Add("doesanyacegrantownerrights", doesAnyAceGrantOwnerRights);
-                ret.Properties.Add("doesanyinheritedacegrantownerrights", doesAnyInheritedAceGrantOwnerRights);
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);


### PR DESCRIPTION
## Description

Returning ProcessACL to return an IAsyncEnumerable for deferred collection processing as it had been before.
This may help resolves issues of memory spikes.
Additionally, moving the aggregate property doesanyacegrantownerrights from the parent domain object and attaching to the ACE instead as IsPermissionForOwnerRightsSid as this is more reflective of an ACE's properties than of the parent.

## Motivation and Context

Investigating a large memory spike https://bloodhoundhq.slack.com/archives/C20NG2L87/p1751305729336129

## How Has This Been Tested?
Local testing on ESC 10 lab

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how access control list (ACL) results are processed for various object types, ensuring consistent evaluation of owner rights permissions.
* **Chores**
  * Removed unused code dependencies for cleaner and more efficient maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->