### PR TITLE
[BED-6140] Add cache invalidation

### DIFF
--- a/src/SharpLinks.cs
+++ b/src/SharpLinks.cs
@@ -140,14 +140,15 @@ namespace Sharphound {
             var path = context.GetCachePath();
             context.Logger.LogTrace("Cache Path: {Path}", path);
 
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
             Cache cache;
             if (!File.Exists(path)) {
                 context.Logger.LogTrace("Cache file does not exist");
-                cache = null;
+                cache = Cache.CreateNewCache(version);
             }
             else if (context.Flags.InvalidateCache) {
                 context.Logger.LogTrace($"Skipping cache load per option {nameof(Options.RebuildCache)}");
-                cache = null;
+                cache = Cache.CreateNewCache(version);
             }
             else {
                 try {
@@ -158,13 +159,12 @@ namespace Sharphound {
                 }
                 catch (Exception e) {
                     context.Logger.LogError("Error loading cache: {exception}, creating new", e);
-                    cache = null;
+                    cache = Cache.CreateNewCache(version);
                 }
 
-                var version = Assembly.GetExecutingAssembly().GetName().Version;
                 if (CacheNeedsInvalidation(cache, version)) {
                     context.Logger.LogInformation("Old cache found, ignoring");
-                    cache = null;
+                    cache = Cache.CreateNewCache(version);
                 }
             }
 

--- a/src/SharpLinks.cs
+++ b/src/SharpLinks.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.DirectoryServices.ActiveDirectory;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security.Principal;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -137,61 +138,106 @@ namespace Sharphound
             context.Logger.LogTrace("Getting cache path");
             var path = context.GetCachePath();
             context.Logger.LogTrace("Cache Path: {Path}", path);
+
             Cache cache;
-            if (!File.Exists(path)) {
+            if (!File.Exists(path))
+            {
                 context.Logger.LogTrace("Cache file does not exist");
                 cache = null;
-            } else
-                try {
+            }
+            else if (context.Flags.InvalidateCache)
+            {
+                context.Logger.LogTrace($"Skipping cache load per option {nameof(Options.RebuildCache)}");
+                cache = null;
+            }
+            else
+            {
+                try
+                {
                     context.Logger.LogTrace("Loading cache from disk");
                     var json = File.ReadAllText(path);
                     cache = JsonConvert.DeserializeObject<Cache>(json, CacheContractResolver.Settings);
                     context.Logger.LogInformation("Loaded cache with stats: {stats}", cache?.GetCacheStats());
-                } catch (Exception e) {
+                }
+                catch (Exception e)
+                {
                     context.Logger.LogError("Error loading cache: {exception}, creating new", e);
                     cache = null;
                 }
+
+                var version = Assembly.GetExecutingAssembly().GetName().Version;
+                if (CacheNeedsInvalidation(cache, version))
+                {
+                    context.Logger.LogInformation("Old cache found, ignoring");
+                    cache = null;
+                }
+            }
 
             CommonLib.InitializeCommonLib(context.Logger, cache);
             context.Logger.LogTrace("Exiting InitCommonLib");
             return context;
         }
 
-        public async Task<IContext> GetDomainsForEnumeration(IContext context) {
+        private bool CacheNeedsInvalidation(Cache cache, Version version)
+        {
+            var threshold = DateTime.Now.Subtract(TimeSpan.FromDays(30));
+            if (cache.CacheCreationDate < threshold) {
+                return true;
+            }
+
+            if (cache.CacheCreationVersion == null || version > cache.CacheCreationVersion)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public async Task<IContext> GetDomainsForEnumeration(IContext context)
+        {
             context.Logger.LogTrace("Entering GetDomainsForEnumeration");
-            if (context.Flags.RecurseDomains) {
+            if (context.Flags.RecurseDomains)
+            {
                 context.Logger.LogInformation(
                     "[RecurseDomains] Cross-domain enumeration may result in reduced data quality");
                 context.Domains = await BuildRecursiveDomainList(context).ToArrayAsync();
                 return context;
             }
 
-            if (context.Flags.SearchForest) {
+            if (context.Flags.SearchForest)
+            {
                 context.Logger.LogInformation(
                     "[SearchForest] Cross-domain enumeration may result in reduced data quality");
-                if (!context.LDAPUtils.GetDomain(context.DomainName, out var dObj)) {
+                if (!context.LDAPUtils.GetDomain(context.DomainName, out var dObj))
+                {
                     context.Logger.LogError("Unable to get domain object for SearchForest");
                     context.Flags.IsFaulted = true;
                     return context;
                 }
 
                 Forest forest;
-                try {
+                try
+                {
                     forest = dObj.Forest;
-                } catch (Exception e) {
+                }
+                catch (Exception e)
+                {
                     context.Logger.LogError("Unable to get forest object for SearchForest: {Message}", e.Message);
                     context.Flags.IsFaulted = true;
                     return context;
                 }
 
                 var temp = new List<EnumerationDomain>();
-                foreach (Domain d in forest.Domains) {
+                foreach (Domain d in forest.Domains)
+                {
                     var entry = d.GetDirectoryEntry().ToDirectoryObject();
-                    if (!entry.TryGetSecurityIdentifier(out var domainSid)) {
+                    if (!entry.TryGetSecurityIdentifier(out var domainSid))
+                    {
                         continue;
                     }
 
-                    temp.Add(new EnumerationDomain() {
+                    temp.Add(new EnumerationDomain()
+                    {
                         Name = d.Name,
                         DomainSid = domainSid
                     });
@@ -203,28 +249,33 @@ namespace Sharphound
                 return context;
             }
 
-            if (!context.LDAPUtils.GetDomain(context.DomainName, out var domainObject)) {
+            if (!context.LDAPUtils.GetDomain(context.DomainName, out var domainObject))
+            {
                 context.Logger.LogError("Unable to resolve a domain to use, manually specify one or check spelling");
                 context.Flags.IsFaulted = true;
                 return context;
             }
 
             var domain = domainObject?.Name ?? context.DomainName;
-            if (domain == null) {
+            if (domain == null)
+            {
                 context.Logger.LogError("Unable to resolve a domain to use, manually specify one or check spelling");
                 context.Flags.IsFaulted = true;
                 return context;
             }
 
             if (domainObject != null && domainObject.GetDirectoryEntry().ToDirectoryObject()
-                    .TryGetSecurityIdentifier(out var sid)) {
+                    .TryGetSecurityIdentifier(out var sid))
+            {
                 context.Domains = new[] {
                     new EnumerationDomain {
                         Name = domain,
                         DomainSid = sid
                     }
                 };
-            } else {
+            }
+            else
+            {
                 context.Domains = new[] {
                     new EnumerationDomain {
                         Name = domain,
@@ -315,11 +366,11 @@ namespace Sharphound
         }
 
         public IContext SaveCacheFile(IContext context) {
-            if (context.Flags.MemCache)
-                return context;
-            // 15. Program exit started. Save the cache file
+            // if (context.Flags.MemCache)
+            //     return context;
+            // // 15. Program exit started. Save the cache file
             var cache = Cache.GetCacheInstance();
-            context.Logger.LogInformation("Saving cache with stats: {stats}", cache.GetCacheStats());
+            // context.Logger.LogInformation("Saving cache with stats: {stats}", cache.GetCacheStats());
             var serialized = JsonConvert.SerializeObject(cache, CacheContractResolver.Settings);
             using var stream =
                 new StreamWriter(context.GetCachePath());

--- a/src/SharpLinks.cs
+++ b/src/SharpLinks.cs
@@ -30,8 +30,7 @@ using SharpHoundCommonLib;
 using SharpHoundCommonLib.Processors;
 using Timer = System.Timers.Timer;
 
-namespace Sharphound
-{
+namespace Sharphound {
     internal class SharpLinks : Links<IContext> {
         /// <summary>
         ///     Define methods that SharpHound executes as part of operation pipeline.
@@ -63,7 +62,8 @@ namespace Sharphound
                 if (!context.LDAPUtils.GetDomain(out var d)) {
                     context.Logger.LogCritical("unable to get current domain");
                     context.Flags.IsFaulted = true;
-                } else {
+                }
+                else {
                     context.DomainName = d.Name;
                     context.Logger.LogInformation("Resolved current domain to {Domain}", d.Name);
                 }
@@ -91,7 +91,8 @@ namespace Sharphound
                     }
 
                     File.Delete(filename);
-                } catch (Exception e) {
+                }
+                catch (Exception e) {
                     context.Logger.LogCritical(e, "unable to write to target directory");
                     context.Flags.IsFaulted = true;
                 }
@@ -140,34 +141,28 @@ namespace Sharphound
             context.Logger.LogTrace("Cache Path: {Path}", path);
 
             Cache cache;
-            if (!File.Exists(path))
-            {
+            if (!File.Exists(path)) {
                 context.Logger.LogTrace("Cache file does not exist");
                 cache = null;
             }
-            else if (context.Flags.InvalidateCache)
-            {
+            else if (context.Flags.InvalidateCache) {
                 context.Logger.LogTrace($"Skipping cache load per option {nameof(Options.RebuildCache)}");
                 cache = null;
             }
-            else
-            {
-                try
-                {
+            else {
+                try {
                     context.Logger.LogTrace("Loading cache from disk");
                     var json = File.ReadAllText(path);
                     cache = JsonConvert.DeserializeObject<Cache>(json, CacheContractResolver.Settings);
                     context.Logger.LogInformation("Loaded cache with stats: {stats}", cache?.GetCacheStats());
                 }
-                catch (Exception e)
-                {
+                catch (Exception e) {
                     context.Logger.LogError("Error loading cache: {exception}, creating new", e);
                     cache = null;
                 }
 
                 var version = Assembly.GetExecutingAssembly().GetName().Version;
-                if (CacheNeedsInvalidation(cache, version))
-                {
+                if (CacheNeedsInvalidation(cache, version)) {
                     context.Logger.LogInformation("Old cache found, ignoring");
                     cache = null;
                 }
@@ -178,66 +173,55 @@ namespace Sharphound
             return context;
         }
 
-        private bool CacheNeedsInvalidation(Cache cache, Version version)
-        {
+        private bool CacheNeedsInvalidation(Cache cache, Version version) {
             var threshold = DateTime.Now.Subtract(TimeSpan.FromDays(30));
             if (cache.CacheCreationDate < threshold) {
                 return true;
             }
 
-            if (cache.CacheCreationVersion == null || version > cache.CacheCreationVersion)
-            {
+            if (cache.CacheCreationVersion == null || version > cache.CacheCreationVersion) {
                 return true;
             }
 
             return false;
         }
 
-        public async Task<IContext> GetDomainsForEnumeration(IContext context)
-        {
+        public async Task<IContext> GetDomainsForEnumeration(IContext context) {
             context.Logger.LogTrace("Entering GetDomainsForEnumeration");
-            if (context.Flags.RecurseDomains)
-            {
+            if (context.Flags.RecurseDomains) {
                 context.Logger.LogInformation(
                     "[RecurseDomains] Cross-domain enumeration may result in reduced data quality");
                 context.Domains = await BuildRecursiveDomainList(context).ToArrayAsync();
                 return context;
             }
 
-            if (context.Flags.SearchForest)
-            {
+            if (context.Flags.SearchForest) {
                 context.Logger.LogInformation(
                     "[SearchForest] Cross-domain enumeration may result in reduced data quality");
-                if (!context.LDAPUtils.GetDomain(context.DomainName, out var dObj))
-                {
+                if (!context.LDAPUtils.GetDomain(context.DomainName, out var dObj)) {
                     context.Logger.LogError("Unable to get domain object for SearchForest");
                     context.Flags.IsFaulted = true;
                     return context;
                 }
 
                 Forest forest;
-                try
-                {
+                try {
                     forest = dObj.Forest;
                 }
-                catch (Exception e)
-                {
+                catch (Exception e) {
                     context.Logger.LogError("Unable to get forest object for SearchForest: {Message}", e.Message);
                     context.Flags.IsFaulted = true;
                     return context;
                 }
 
                 var temp = new List<EnumerationDomain>();
-                foreach (Domain d in forest.Domains)
-                {
+                foreach (Domain d in forest.Domains) {
                     var entry = d.GetDirectoryEntry().ToDirectoryObject();
-                    if (!entry.TryGetSecurityIdentifier(out var domainSid))
-                    {
+                    if (!entry.TryGetSecurityIdentifier(out var domainSid)) {
                         continue;
                     }
 
-                    temp.Add(new EnumerationDomain()
-                    {
+                    temp.Add(new EnumerationDomain() {
                         Name = d.Name,
                         DomainSid = domainSid
                     });
@@ -249,24 +233,21 @@ namespace Sharphound
                 return context;
             }
 
-            if (!context.LDAPUtils.GetDomain(context.DomainName, out var domainObject))
-            {
+            if (!context.LDAPUtils.GetDomain(context.DomainName, out var domainObject)) {
                 context.Logger.LogError("Unable to resolve a domain to use, manually specify one or check spelling");
                 context.Flags.IsFaulted = true;
                 return context;
             }
 
             var domain = domainObject?.Name ?? context.DomainName;
-            if (domain == null)
-            {
+            if (domain == null) {
                 context.Logger.LogError("Unable to resolve a domain to use, manually specify one or check spelling");
                 context.Flags.IsFaulted = true;
                 return context;
             }
 
             if (domainObject != null && domainObject.GetDirectoryEntry().ToDirectoryObject()
-                    .TryGetSecurityIdentifier(out var sid))
-            {
+                    .TryGetSecurityIdentifier(out var sid)) {
                 context.Domains = new[] {
                     new EnumerationDomain {
                         Name = domain,
@@ -274,8 +255,7 @@ namespace Sharphound
                     }
                 };
             }
-            else
-            {
+            else {
                 context.Domains = new[] {
                     new EnumerationDomain {
                         Name = domain,


### PR DESCRIPTION
## Description
Invalidate cache when version changed, or when RebuildCache command flag specified.

## Motivation and Context
https://specterops.atlassian.net/browse/BED-6140

## How Has This Been Tested?
On lab VM

## Screenshots (if appropriate):
<img width="855" alt="image" src="https://github.com/user-attachments/assets/234d2882-8d79-44a9-bdfe-e87e924740f2" />
<img width="856" alt="image" src="https://github.com/user-attachments/assets/2950bc22-08cf-4512-abcd-9ce6329ef1fa" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cache management with automatic invalidation based on cache age (older than 30 days) or outdated version.
  * Enhanced logging of cache statistics during loading.

* **Bug Fixes**
  * Improved consistency in exception handling and formatting throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->