### PR TITLE
Support HasSIDHistory on Group Collection

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -25,8 +25,8 @@
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="SharpHoundCommon" Version="4.2.8" />
-        <PackageReference Include="SharpHoundRPC" Version="4.2.8" />
+        <PackageReference Include="SharpHoundCommon" Version="4.3.0" />
+        <PackageReference Include="SharpHoundRPC" Version="4.3.0" />
         <PackageReference Include="SharpZipLib" Version="1.3.3" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -416,7 +416,7 @@ namespace Sharphound.Runtime {
                     .ToArrayAsync(cancellationToken: _cancellationToken);
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps)) {
-                var groupProps = await _ldapPropertyProcessor.ReadGroupProperties(entry, resolvedSearchResult);
+                var groupProps = await _ldapPropertyProcessor.ReadGroupPropertiesAsync(entry, resolvedSearchResult);
                 ret.Properties = ContextUtils.Merge(ret.Properties, groupProps.Props);
                 ret.HasSIDHistory = groupProps.SidHistory;
                 if (_context.Flags.CollectAllProperties) {

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -416,8 +416,9 @@ namespace Sharphound.Runtime {
                     .ToArrayAsync(cancellationToken: _cancellationToken);
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps)) {
-                var groupProps = LdapPropertyProcessor.ReadGroupProperties(entry);
-                ret.Properties = ContextUtils.Merge(ret.Properties, groupProps);
+                var groupProps = await _ldapPropertyProcessor.ReadGroupProperties(entry, resolvedSearchResult);
+                ret.Properties = ContextUtils.Merge(ret.Properties, groupProps.Props);
+                ret.HasSIDHistory = groupProps.SidHistory;
                 if (_context.Flags.CollectAllProperties) {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);


### PR DESCRIPTION
## Description

This change Adds Support for Collecting HasSidHistory on SharpHound. 

## Motivation and Context

Resolves [BED-4881](https://specterops.atlassian.net/browse/BED-4881)

## How Has This Been Tested?

This has been tested by running a compiled program on lab with the value that was present. 

## Screenshots (if appropriate):

<img width="616" height="654" alt="image" src="https://github.com/user-attachments/assets/73d7f9d8-8880-41c1-901e-0acdf583baeb" />

## Types of changes

This change makes a change in SharpHound to handle the breaking interface present in SharpHoundCommon

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-4881]: https://specterops.atlassian.net/browse/BED-4881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in processing group properties and SID history for group objects.
  * Updated package dependencies to the latest versions for enhanced stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->