### PR TITLE
feat: build pipeline should target SHC git-dev for merge status checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           done
           CSPROJ_FILES=$(grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundRPC"' .)
           for csproj in "${CSPROJ_FILES[@]}"; do
-            sed -i "s|<PackageReference Include=\"SharpHoundCommon\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundRPC\" Version=\"git-dev\" />|" $csproj
+            sed -i "s|<PackageReference Include=\"SharpHoundRPC\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundRPC\" Version=\"git-dev\" />|" $csproj
           done
 
       - name: Restore Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,11 @@ jobs:
         run: |
           grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundCommon"' . \
             | while IFS= read -r csproj; do
-                sed -i "s|<PackageReference Include=\"SharpHoundCommon\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundCommon\" Version=\"git-dev\" />|" $csproj
+                sed -i "s|<PackageReference Include=\"SharpHoundCommon\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundCommon\" Version=\"0.0.0-git-dev\" />|" $csproj
               done
           grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundRPC"' . \
             | while IFS= read -r csproj; do
-                sed -i "s|<PackageReference Include=\"SharpHoundRPC\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundRPC\" Version=\"git-dev\" />|" $csproj
+                sed -i "s|<PackageReference Include=\"SharpHoundRPC\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundRPC\" Version=\"0.0.0-git-dev\" />|" $csproj
               done
 
       - name: Restore Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,23 @@ jobs:
     name: Build (${{ matrix.release.type }})
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 5.0.x
+
+      - name: Replace SharpHound library refs with git-dev
+        run: |
+          CSPROJ_FILES=$(grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundCommon"' .)
+          for csproj in "${CSPROJ_FILES[@]}"; do
+            sed -i "s|<PackageReference Include=\"SharpHoundCommon\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundCommon\" Version=\"git-dev\" />|" $csproj
+          done
+          CSPROJ_FILES=$(grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundRPC"' .)
+          for csproj in "${CSPROJ_FILES[@]}"; do
+            sed -i "s|<PackageReference Include=\"SharpHoundCommon\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundRPC\" Version=\"git-dev\" />|" $csproj
+          done
 
       - name: Restore Dependencies
         run: dotnet restore
@@ -43,7 +54,7 @@ jobs:
 
       - name: Update Rolling Release
         if: "! startsWith(github.event_name, 'pull_request')"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: Rolling Release (unstable)
           tag_name: rolling

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             | while IFS= read -r csproj; do
                 sed -i "s|<PackageReference Include=\"SharpHoundCommon\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundCommon\" Version=\"git-dev\" />|" $csproj
               done
-          CSPROJ_FILES=$(grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundRPC"' .) \
+          grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundRPC"' . \
             | while IFS= read -r csproj; do
                 sed -i "s|<PackageReference Include=\"SharpHoundRPC\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundRPC\" Version=\"git-dev\" />|" $csproj
               done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: Build
 
 on:
-  push:
-    branches: [dev]
   pull_request:
-    branches: [dev]
+    types: [opened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ dev ]
+    branches: [dev]
   pull_request:
-    branches: [ dev ]
+    branches: [dev]
 
 jobs:
   build:
@@ -17,9 +17,9 @@ jobs:
       matrix:
         release:
           - type: Debug
-            suffix: '-debug'
+            suffix: "-debug"
           - type: Release
-            suffix: ''
+            suffix: ""
 
     name: Build (${{ matrix.release.type }})
 
@@ -33,14 +33,14 @@ jobs:
 
       - name: Replace SharpHound library refs with git-dev
         run: |
-          CSPROJ_FILES=$(grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundCommon"' .)
-          for csproj in "${CSPROJ_FILES[@]}"; do
-            sed -i "s|<PackageReference Include=\"SharpHoundCommon\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundCommon\" Version=\"git-dev\" />|" $csproj
-          done
-          CSPROJ_FILES=$(grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundRPC"' .)
-          for csproj in "${CSPROJ_FILES[@]}"; do
-            sed -i "s|<PackageReference Include=\"SharpHoundRPC\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundRPC\" Version=\"git-dev\" />|" $csproj
-          done
+          grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundCommon"' . \
+            | while IFS= read -r csproj; do
+                sed -i "s|<PackageReference Include=\"SharpHoundCommon\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundCommon\" Version=\"git-dev\" />|" $csproj
+              done
+          CSPROJ_FILES=$(grep -rl --include="*.csproj" 'PackageReference Include="SharpHoundRPC"' .) \
+            | while IFS= read -r csproj; do
+                sed -i "s|<PackageReference Include=\"SharpHoundRPC\" Version=\"[^\"]*\" />|<PackageReference Include=\"SharpHoundRPC\" Version=\"git-dev\" />|" $csproj
+              done
 
       - name: Restore Dependencies
         run: dotnet restore


### PR DESCRIPTION
## Description
We'd like to decouple Sharphound development from necessarily referencing latest Common lib stable release.  Would rather it builds against latest main branch developments for PR merge checks.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build process to use newer versions of build and release tools.
  * Improved handling of specific package versions during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->