### PR TITLE
Add netlogon reg key

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -402,7 +402,9 @@ namespace Sharphound.Runtime {
                 DCRegistryData dCRegistryData = new() {
                     CertificateMappingMethods = _dcRegistryProcessor.GetCertificateMappingMethods(apiName),
                     StrongCertificateBindingEnforcement =
-                        _dcRegistryProcessor.GetStrongCertificateBindingEnforcement(apiName)
+                        _dcRegistryProcessor.GetStrongCertificateBindingEnforcement(apiName),
+                    VulnerableNetlogonSecurityDescriptor =
+                        _dcRegistryProcessor.GetVulnerableNetlogonSecurityDescriptor(apiName)
                 };
 
                 ret.DCRegistryData = dCRegistryData;


### PR DESCRIPTION
## Description

Collect the registry key that holds the security descriptor that determines who can perform the vulnerable version of netlogon

## Motivation and Context

Ticket: BED-6429

Depends on this Commonlib PR: https://github.com/SpecterOps/SharpHoundCommon/pull/244

## How Has This Been Tested?

Locally in GOAD lab.

## Screenshots (if appropriate):

From corresponding BloodHound PR:
<img width="461" height="106" alt="image" src="https://github.com/user-attachments/assets/d059cd18-7a4b-4ea0-bb9b-25c38a87c0cc" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain controller registry export now includes a Netlogon security descriptor field, adding more detail to exported DC registry data.
  * Enables richer analysis of Netlogon-related security settings in exported results and downstream tools.
  * Additive change — existing behavior and workflows remain unchanged while providing enhanced registry detail for auditing and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->