### PR TITLE
BED-6441 - Adding back Aces to Domain Object Collection

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -492,6 +492,7 @@ namespace Sharphound.Runtime {
             if (_methods.HasFlag(CollectionMethod.ACL)) {
                 var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
                     .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Aces = aces;
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);


### PR DESCRIPTION
## Description

A small fix to add back some logic that was accidentally removed.

## Motivation and Context

Resolves [BED-6441](https://specterops.atlassian.net/browse/BED-6441)

## How Has This Been Tested?

This has been tested by running collection with the current version, and a build created using this change. The Aces were then collected for domain objects

## Screenshots (if appropriate):

<img width="613" height="514" alt="image" src="https://github.com/user-attachments/assets/d49ca122-ddaa-401d-8f72-3bec275e438c" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My changes include a database migration.


[BED-6441]: https://specterops.atlassian.net/browse/BED-6441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Domain items now include their full permission entries, ensuring permission details display accurately.
  * Improves reliability of permission-aware views, audits, and reports by consistently reflecting current access settings.
  * Ownership and inheritance indicators remain unchanged but now align with the populated permission data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->