### PR TITLE
[BED-6485] chore: bump SHC ref to 4.3.2

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -25,8 +25,8 @@
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="SharpHoundCommon" Version="4.3.1" />
-        <PackageReference Include="SharpHoundRPC" Version="4.3.1" />
+        <PackageReference Include="SharpHoundCommon" Version="4.3.2" />
+        <PackageReference Include="SharpHoundRPC" Version="4.3.2" />
         <PackageReference Include="SharpZipLib" Version="1.3.3" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />


### PR DESCRIPTION
## Description
SHC reference version bump.

## Motivation and Context
https://specterops.atlassian.net/browse/BED-6485

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying libraries to the latest patch versions, improving stability, compatibility, and incorporating upstream fixes.
  * This maintenance upgrade reduces potential edge-case failures and prepares the app for future enhancements.
  * No changes to commands, output, or user workflows; behavior remains the same.
  * Minor performance and reliability improvements may be observed in certain environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->