### PR TITLE
[BED-6524] Build workflow should run on all PRs against main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
 name: Build
 
 on:
-  push:
-    branches: [ dev ]
   pull_request:
-    branches: [ dev ]
+    branches: [ 2.X ]
+    types: [ opened, synchronize ]
 
 jobs:
   build:
@@ -24,10 +23,10 @@ jobs:
     name: Build (${{ matrix.release.type }})
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 5.0.x
 
@@ -43,7 +42,7 @@ jobs:
 
       - name: Update Rolling Release
         if: "! startsWith(github.event_name, 'pull_request')"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: Rolling Release (unstable)
           tag_name: rolling


### PR DESCRIPTION
## Description
Build pipeline is not configured to run on PRs targeting our main branch '2.X'
Also took the opportunity to update github actions versions

## Motivation and Context
[BED-6524](https://specterops.atlassian.net/browse/BED-6524)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-6524]: https://specterops.atlassian.net/browse/BED-6524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI to run on pull requests targeting 2.X only.
  * Refreshed GitHub Actions versions for checkout, .NET setup, and release steps.
  * Minor workflow formatting adjustments.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->