### PR TITLE
[BED-6645] SharpHound RegistrySessions status incorrectly reports NetWkstaUserEnum result

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -289,7 +289,7 @@ namespace Sharphound.Runtime {
                     ret.RegistrySessions = registrySessionResult;
                     if (_context.Flags.DumpComputerStatus)
                         await compStatusChannel.Writer.WriteAsync(new CSVComputerStatus {
-                            Status = privSessionResult.Collected ? StatusSuccess : privSessionResult.FailureReason,
+                            Status = registrySessionResult.Collected ? StatusSuccess : registrySessionResult.FailureReason,
                             Task = "RegistrySessions",
                             ComputerName = resolvedSearchResult.DisplayName
                         }, _cancellationToken);


### PR DESCRIPTION
When --trackcomputercalls is enabled, the RegistrySessions CSV status was incorrectly checking privSessionResult instead of registrySessionResult, causing it to report the NetWkstaUserEnum status instead of the actual registry enumeration result.

## Description

<!--- Describe your changes in detail -->

When --trackcomputercalls is enabled, the CSV status output for the RegistrySessions task incorrectly uses the privSessionResult variable (from NetWkstaUserEnum) instead of registrySessionResult (from the registry query). This causes the RegistrySessions row in the CSV to show incorrect status information.

Changed line 303 to use registrySessionResult.Collected instead of
privSessionResult.Collected for accurate status reporting.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://specterops.atlassian.net/browse/BED-6645

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test environment:
1. Tested on production SharpHound build from main branch (commit [54ac6dd](https://github.com/SpecterOps/SharpHound/commit/54ac6dd4d47f27065b3f9c4397ae46c93d3f5e46))
2. Compiled fixed version locally with the corrected variable reference

Reproduction Steps:
1. Disabled Remote Registry service on a computer
2. Ran baseline SharpHound from main branch: `.\SharpHound.exe -c session,loggedon --computerfile .\computers.txt --nozip --memcache --trackcomputercalls`
3. Examined generated *_compstatus.csv file
4. Confirmed bug: RegistrySessions status duplicated NetWkstaUserEnum result instead of showing independent registry enumeration status. Confirmed in computers.json where result of RegistrySessions collection was `false`

Validation Steps:
1. Applied fix
2. Ran fixed build: `.\SharpHound.exe -c session,loggedon --computerfile .\computers.txt --nozip --memcache --trackcomputercalls`
3. Confirmed fix: RegistrySessions now correctly reports its own status, independent of NetWkstaUserEnum result

Attached relevant output files pre-fix and post-fix.
[postfix - data registry disabled.json](https://github.com/user-attachments/files/22972200/postfix.-.data.registry.disabled.json)
[prefix - compstatus registry enabled.csv](https://github.com/user-attachments/files/22972202/prefix.-.compstatus.registry.enabled.csv)
[prefix - data registry disabled.json](https://github.com/user-attachments/files/22972203/prefix.-.data.registry.disabled.json)
[prefix - compstatus registry disabled.csv](https://github.com/user-attachments/files/22972204/prefix.-.compstatus.registry.disabled.csv)
[prefix - data registry enabled.json](https://github.com/user-attachments/files/22972206/prefix.-.data.registry.enabled.json)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Updated status reporting for registry session entries to accurately reflect collection status or associated failure reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->