### PR TITLE
[BED-6646] NullReferenceException when using --trackcomputercalls with collection methods that don't enumerate computers

### DIFF
--- a/src/Writers/CompStatusWriter.cs
+++ b/src/Writers/CompStatusWriter.cs
@@ -45,6 +45,8 @@ namespace Sharphound.Writers
 
         internal override async Task FlushWriter()
         {
+            if (_streamWriter == null) return;
+
             await WriteData();
             await _streamWriter.FlushAsync();
             CloseLog();

--- a/src/Writers/CompStatusWriter.cs
+++ b/src/Writers/CompStatusWriter.cs
@@ -45,7 +45,8 @@ namespace Sharphound.Writers
 
         internal override async Task FlushWriter()
         {
-            if (_streamWriter == null) return;
+            if (!FileCreated)
+                return;
 
             await WriteData();
             await _streamWriter.FlushAsync();


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

When `--trackcomputercalls` is used with collection methods that don't perform computer enumeration (e.g., `dconly`, `group`, `trusts´), SharpHound crashes during end of collection. JSONs and ZIP is still produced.

CompStatusWriter crashes with a NullReferenceException during shutdown. The _streamWriter field remains null because CreateFile() is only called when the first status object is accepted, but no status objects are generated when computers aren't enumerated.

Output from crash:
```
> .\SharpHound.exe --collectionmethods dconly --trackcomputercalls
2025-10-17T07:48:28.0565190-07:00|INFORMATION|This version of SharpHound is compatible with the 5.0.0 Release of BloodHound
2025-10-17T07:48:28.2645935-07:00|INFORMATION|Resolved Collection Methods: Group, GPOLocalGroup, Trusts, ACL, Container, ObjectProps, CertServices
2025-10-17T07:48:28.3553395-07:00|INFORMATION|Initializing SharpHound at 7:48 AM on 10/17/2025
2025-10-17T07:48:28.4630355-07:00|INFORMATION|Resolved current domain to barkside.local
2025-10-17T07:48:29.6413993-07:00|INFORMATION|Flags: Group, GPOLocalGroup, Trusts, ACL, Container, ObjectProps, CertServices
2025-10-17T07:48:29.7331849-07:00|INFORMATION|Beginning LDAP search for barkside.local
2025-10-17T07:48:29.8912400-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.8912400-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.8912400-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.8912400-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.8923542-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.8958506-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.8993268-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9452515-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9487407-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9522533-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9522533-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9537149-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9541719-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9541719-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9694374-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9714149-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9541719-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9537731-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9748930-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9679343-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.0032638-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9748930-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9907994-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9679343-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9963006-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9768733-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9851117-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9679343-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:29.9855813-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.0538408-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.0714737-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.0716737-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.0772227-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.1195114-07:00|INFORMATION|Beginning LDAP search for barkside.local Configuration NC
2025-10-17T07:48:30.1282331-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2464616-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2464616-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2552700-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2552700-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2552700-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2477620-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2548241-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2464616-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2570159-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.2464616-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.3954493-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.3961764-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.3954493-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.3960525-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.3963797-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:30.3960525-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T07:48:31.3014496-07:00|INFORMATION|Producer has finished, closing LDAP channel
2025-10-17T07:48:31.3055053-07:00|INFORMATION|LDAP channel closed, waiting for consumers
2025-10-17T07:48:34.5329884-07:00|INFORMATION|Consumers finished, closing output channel
2025-10-17T07:48:34.5607663-07:00|INFORMATION|Output channel closed, waiting for output task to complete
Closing writers
2025-10-17T07:48:34.6794964-07:00|INFORMATION|Status: 314 objects finished (+314 78.5)/s -- Using 80 MB RAM
2025-10-17T07:48:34.6794964-07:00|INFORMATION|Enumeration finished in 00:00:04.9561639
2025-10-17T07:48:34.7764095-07:00|ERROR|Error running SharpHound: Object reference not set to an instance of an object.
   at Sharphound.Writers.CompStatusWriter.<FlushWriter>d__7.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Sharphound.Writers.CompStatusWriter.<StartWriter>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Sharphound.Runtime.CollectionTask.<StartCollection>d__11.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Sharphound.SharpLinks.<AwaitBaseRunCompletion>d__7.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Sharphound.Program.<StartCollection>d__1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Sharphound.Program.<>c__DisplayClass0_0.<<Main>b__1>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at CommandLine.ParserResultExtensions.<WithParsedAsync>d__20`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Sharphound.Program.<Main>d__0.MoveNext()
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://specterops.atlassian.net/browse/BED-6646

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Build successful (dotnet build)
- Edge case fixed: .\SharpHound.exe -c dconly --trackcomputercalls (no crash)
- Normal case works: .\SharpHound.exe -c Session,LoggedOn --trackcomputercalls (compstatus CSV successfully created)
- Without flags work: .\SharpHound.exe

Output from fix:
```
> .\SharpHound.exe --collectionmethods dconly --trackcomputercalls
2025-10-17T08:03:00.7511398-07:00|INFORMATION|This version of SharpHound is compatible with the 5.0.0 Release of BloodHound
2025-10-17T08:03:00.9939288-07:00|INFORMATION|Resolved Collection Methods: Group, GPOLocalGroup, Trusts, ACL, Container, ObjectProps, CertServices
2025-10-17T08:03:01.0260469-07:00|INFORMATION|Initializing SharpHound at 8:03 AM on 10/17/2025
2025-10-17T08:03:01.0719281-07:00|INFORMATION|Resolved current domain to barkside.local
2025-10-17T08:03:01.2633035-07:00|INFORMATION|Flags: Group, GPOLocalGroup, Trusts, ACL, Container, ObjectProps, CertServices
2025-10-17T08:03:01.3667971-07:00|INFORMATION|Beginning LDAP search for barkside.local
2025-10-17T08:03:01.5374737-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5409533-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5443494-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5444332-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5465742-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5448105-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5483125-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5863327-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5865720-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5874583-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5863327-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5879379-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5882324-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5966368-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6091300-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5914101-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5913290-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6091300-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6090650-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6090650-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6178295-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6120775-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5891959-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.5882324-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6266354-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6213632-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6120775-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6318555-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6405554-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6961791-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6962293-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.6979699-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.7387973-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.7527547-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.7883660-07:00|INFORMATION|Beginning LDAP search for barkside.local Configuration NC
2025-10-17T08:03:01.8818320-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.8819823-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.8837220-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.8818320-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.8837220-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.8818320-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.8998861-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.8998861-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:01.9122044-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:02.0815687-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:02.1047051-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:02.1051540-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:02.1047051-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:02.1047051-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:02.1050257-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:02.1050257-07:00|INFORMATION|[CommonLib ACLProc]Building GUID Cache for BARKSIDE.LOCAL
2025-10-17T08:03:02.2125413-07:00|INFORMATION|[CommonLib TestLdapConnection]Execution time Average: 18.267178125ms, StdDiv: 13.7170111233674ms
2025-10-17T08:03:02.6032909-07:00|INFORMATION|Producer has finished, closing LDAP channel
2025-10-17T08:03:02.6249603-07:00|INFORMATION|LDAP channel closed, waiting for consumers
2025-10-17T08:03:06.3543200-07:00|INFORMATION|Consumers finished, closing output channel
Closing writers
2025-10-17T08:03:06.3802713-07:00|INFORMATION|Output channel closed, waiting for output task to complete
2025-10-17T08:03:06.4746728-07:00|INFORMATION|Status: 314 objects finished (+314 62.8)/s -- Using 73 MB RAM
2025-10-17T08:03:06.4746728-07:00|INFORMATION|Enumeration finished in 00:00:05.1206711
2025-10-17T08:03:06.5948460-07:00|INFORMATION|Saving cache with stats: 12 ID to type mappings.
 0 name to SID mappings.
 0 machine sid mappings.
 3 sid to domain mappings.
 0 global catalog mappings.
2025-10-17T08:03:06.6467085-07:00|INFORMATION|SharpHound Enumeration Completed at 8:03 AM on 10/17/2025! Happy Graphing!
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash that could occur when flushing data before the underlying writer was fully initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->