### PR TITLE
Updated required .NET to 4.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dotnet build
 
 ## Requirements
 
-SharpHound is designed targeting .Net 4.6.2. SharpHound must be run from the context of a domain user, either directly through a logon or through another method such as RUNAS.
+SharpHound is designed targeting .Net 4.7.2. SharpHound must be run from the context of a domain user, either directly through a logon or through another method such as RUNAS.
 
 # SharpHound
 


### PR DESCRIPTION
Updated required .NET to 4.7.2

## Description

Updated required .NET to 4.7.2, current mentioning of .Net 4.6.2 does not meet the requirements.

## Motivation and Context

If this requirement for .NET 4.7.2 is not followed, SharpHound fails with:
"|ERROR|The .Net Runtime is not compatible with SharpHound. Please update to .Net 4.7.2."

## How Has This Been Tested?

On a Windows System, Windows Server 2016, with the default .Net 4.6.2.
SharpHound 2.8.0
Exectution fails.

Install .NET to 4.7.2.

Execution works

## Screenshots (if appropriate):
<img width="999" height="667" alt="image" src="https://github.com/user-attachments/assets/16bae100-74c0-4a85-8ef3-3da429d3243c" />
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Documentation updates are needed, and have been made accordingly.
-   [X] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum .NET framework requirement from 4.6.2 to 4.7.2 in project requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->