### PR TITLE
Add CompStatus Events to CertAbuseProcessor BED-6967

### DIFF
--- a/src/Runtime/CollectionTask.cs
+++ b/src/Runtime/CollectionTask.cs
@@ -99,7 +99,6 @@ namespace Sharphound.Runtime
                 await _outputChannel.Writer.WriteAsync(wkp);
             }
                 
-
             _outputChannel.Writer.Complete();
             _compStatusChannel?.Writer.Complete();
             _log.LogInformation("Output channel closed, waiting for output task to complete");
@@ -112,7 +111,7 @@ namespace Sharphound.Runtime
         internal async Task ConsumeSearchResults()
         {
             var log = _context.Logger;
-            var processor = new ObjectProcessors(_context, log);
+            var processor = new ObjectProcessors(_context, log, _compStatusChannel);
             var watch = new Stopwatch();
             var threadId = Thread.CurrentThread.ManagedThreadId;
             
@@ -130,7 +129,7 @@ namespace Sharphound.Runtime
 
                     log.LogTrace("Consumer {ThreadID} started processing {obj} ({type})", threadId, res.DisplayName, res.ObjectType);
                     watch.Start();
-                    var processed = await processor.ProcessObject(item, res, _compStatusChannel);
+                    var processed = await processor.ProcessObject(item, res);
                     watch.Stop();
                     log.LogTrace("Consumer {ThreadID} took {time} ms to process {obj}", threadId,
                         watch.Elapsed.TotalMilliseconds, res.DisplayName);
@@ -147,6 +146,8 @@ namespace Sharphound.Runtime
                 {
                     log.LogError(e, "error in consumer");
                 }
+                
+            processor.ClearEventHandlers();
 
             log.LogDebug("Consumer task on thread {id} completed", Thread.CurrentThread.ManagedThreadId);
         }

--- a/src/Runtime/LDAPConsumer.cs
+++ b/src/Runtime/LDAPConsumer.cs
@@ -18,7 +18,7 @@ namespace Sharphound.Runtime
             int id)
         {
             var log = context.Logger;
-            var processor = new ObjectProcessors(context, log);
+            var processor = new ObjectProcessors(context, log, computerStatusChannel);
             var watch = new Stopwatch();
             var threadId = Thread.CurrentThread.ManagedThreadId;
 
@@ -34,7 +34,7 @@ namespace Sharphound.Runtime
 
                     log.LogTrace("Consumer {ThreadID} started processing {obj} ({type})", threadId, res.DisplayName, res.ObjectType);
                     watch.Start();
-                    var processed = await processor.ProcessObject(item, res, computerStatusChannel);
+                    var processed = await processor.ProcessObject(item, res);
                     watch.Stop();
                     log.LogTrace("Consumer {ThreadID} took {time} ms to process {obj}", threadId,
                         watch.Elapsed.TotalMilliseconds, res.DisplayName);
@@ -51,6 +51,8 @@ namespace Sharphound.Runtime
                 {
                     log.LogError(e, "error in consumer");
                 }
+                
+            processor.ClearEventHandlers();
 
             log.LogDebug("Consumer task on thread {id} completed", Thread.CurrentThread.ManagedThreadId);
         }

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -50,7 +50,7 @@ namespace Sharphound.Runtime {
             _domainTrustProcessor = new DomainTrustProcessor(context.LDAPUtils);
             _computerAvailability = new ComputerAvailability(context.PortScanTimeout,
                 skipPortScan: context.Flags.SkipPortScan, skipPasswordCheck: context.Flags.SkipPasswordAgeCheck);
-            _certAbuseProcessor = new CertAbuseProcessor(context.LDAPUtils);
+            _certAbuseProcessor = new CertAbuseProcessor(context.LDAPUtils, new RegistryAccessor());
             _dcRegistryProcessor = new DCRegistryProcessor(context.LDAPUtils);
             _computerSessionProcessor = new ComputerSessionProcessor(context.LDAPUtils,
                 doLocalAdminSessionEnum: context.Flags.DoLocalAdminSessionEnum,
@@ -806,7 +806,7 @@ namespace Sharphound.Runtime {
                         IsUserSpecifiesSanEnabled = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(dnsHostName, caName, ret.HostingComputer),
                         EnrollmentAgentRestrictions = await _certAbuseProcessor.ProcessEAPermissions(caName,
                             resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer),
-                        RoleSeparationEnabled = await _certAbuseProcessor.RoleSeparationEnabled(dnsHostName, caName, ret.HostingComputer),
+                        RoleSeparationEnabled = await _certAbuseProcessor.IsRoleSeparationEnabled(dnsHostName, caName, ret.HostingComputer),
 
                         // The CASecurity exist in the AD object DACL and in registry of the CA server. We prefer to use the values from registry as they are the ground truth.
                         // If changes are made on the CA server, registry and the AD object is updated. If changes are made directly on the AD object, the CA server registry is not updated.

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -13,6 +13,7 @@ using SharpHoundCommonLib.DirectoryObjects;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
 using SharpHoundCommonLib.Processors;
+using SharpHoundRPC.Wrappers;
 using Container = SharpHoundCommonLib.OutputTypes.Container;
 using Group = SharpHoundCommonLib.OutputTypes.Group;
 using Label = SharpHoundCommonLib.Enums.Label;
@@ -50,7 +51,7 @@ namespace Sharphound.Runtime {
             _domainTrustProcessor = new DomainTrustProcessor(context.LDAPUtils);
             _computerAvailability = new ComputerAvailability(context.PortScanTimeout,
                 skipPortScan: context.Flags.SkipPortScan, skipPasswordCheck: context.Flags.SkipPasswordAgeCheck);
-            _certAbuseProcessor = new CertAbuseProcessor(context.LDAPUtils, new RegistryAccessor());
+            _certAbuseProcessor = new CertAbuseProcessor(context.LDAPUtils, new RegistryAccessor(), new SAMServerAccessor());
             _dcRegistryProcessor = new DCRegistryProcessor(context.LDAPUtils);
             _computerSessionProcessor = new ComputerSessionProcessor(context.LDAPUtils,
                 doLocalAdminSessionEnum: context.Flags.DoLocalAdminSessionEnum,

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -40,7 +40,9 @@ namespace Sharphound.Runtime {
         private readonly WebClientServiceProcessor _webClientProcessor;
         private readonly SmbProcessor _smbProcessor;
         private readonly ConcurrentDictionary<string, RegistryProcessor> _registryProcessorMap = new();
-        public ObjectProcessors(IContext context, ILogger log) {
+        private readonly Channel<CSVComputerStatus> _compStatusChannel;
+        
+        public ObjectProcessors(IContext context, ILogger log, Channel<CSVComputerStatus> compStatusChannel) {
             _context = context;
             _aclProcessor = new ACLProcessor(context.LDAPUtils);
             _spnProcessor = new SPNProcessors(context.LDAPUtils);
@@ -63,15 +65,29 @@ namespace Sharphound.Runtime {
             _methods = context.ResolvedCollectionMethods;
             _cancellationToken = context.CancellationTokenSource.Token;
             _log = log;
+            _compStatusChannel = compStatusChannel;
+
+            _certAbuseProcessor.ComputerStatusEvent += HandleCompStatusEvent;
         }
 
-        internal async Task<OutputBase> ProcessObject(IDirectoryObject entry,
-            ResolvedSearchResult resolvedSearchResult, Channel<CSVComputerStatus> compStatusChannel) {
+        internal void ClearEventHandlers() {
+            _certAbuseProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
+        }
+
+        private async Task HandleCompStatusEvent(CSVComputerStatus status) {
+            try {
+                await _compStatusChannel.Writer.WriteAsync(status, _cancellationToken);
+            } catch (Exception e) {
+                _log.LogWarning(e, "Caught exception writing to compstatus writer");
+            }
+        }
+
+        internal async Task<OutputBase> ProcessObject(IDirectoryObject entry, ResolvedSearchResult resolvedSearchResult) {
             switch (resolvedSearchResult.ObjectType) {
                 case Label.User:
                     return await ProcessUserObject(entry, resolvedSearchResult);
                 case Label.Computer:
-                    return await ProcessComputerObject(entry, resolvedSearchResult, compStatusChannel);
+                    return await ProcessComputerObject(entry, resolvedSearchResult);
                 case Label.Group:
                     return await ProcessGroupObject(entry, resolvedSearchResult);
                 case Label.GPO:
@@ -88,7 +104,7 @@ namespace Sharphound.Runtime {
                 case Label.AIACA:
                     return await ProcessAIACA(entry, resolvedSearchResult);
                 case Label.EnterpriseCA:
-                    return await ProcessEnterpriseCA(entry, resolvedSearchResult, compStatusChannel);
+                    return await ProcessEnterpriseCA(entry, resolvedSearchResult);
                 case Label.NTAuthStore:
                     return await ProcessNTAuthStore(entry, resolvedSearchResult);
                 case Label.CertTemplate:
@@ -208,8 +224,7 @@ namespace Sharphound.Runtime {
 
         private async Task<Computer> ProcessComputerObject(
             IDirectoryObject entry,
-            ResolvedSearchResult resolvedSearchResult,
-            Channel<CSVComputerStatus> compStatusChannel
+            ResolvedSearchResult resolvedSearchResult
         ) {
             var ret = new Computer {
                 ObjectIdentifier = resolvedSearchResult.ObjectId,
@@ -280,8 +295,7 @@ namespace Sharphound.Runtime {
             var availability = await _computerAvailability.IsComputerAvailable(resolvedSearchResult, entry);
 
             if (!availability.Connectable) {
-                await compStatusChannel.Writer.WriteAsync(availability.GetCSVStatus(resolvedSearchResult.DisplayName),
-                    _cancellationToken);
+                await HandleCompStatusEvent(availability.GetCSVStatus(resolvedSearchResult.DisplayName));
                 ret.Status = availability;
                 return ret;
             }
@@ -297,12 +311,12 @@ namespace Sharphound.Runtime {
                     resolvedSearchResult.ObjectId, resolvedSearchResult.Domain);
                 ret.Sessions = sessionResult;
                 if (_context.Flags.DumpComputerStatus)
-                    await compStatusChannel.Writer.WriteAsync(new CSVComputerStatus {
+                    await HandleCompStatusEvent(new CSVComputerStatus {
                         Status = sessionResult.Collected ? StatusSuccess : sessionResult.FailureReason,
                         Task = "NetSessionEnum",
                         ComputerName = resolvedSearchResult.DisplayName,
                         ObjectId = resolvedSearchResult.ObjectId,
-                    }, _cancellationToken);
+                    });
             }
 
             if (_methods.HasFlag(CollectionMethod.LoggedOn)) {
@@ -313,12 +327,12 @@ namespace Sharphound.Runtime {
                 ret.PrivilegedSessions = privSessionResult;
 
                 if (_context.Flags.DumpComputerStatus)
-                    await compStatusChannel.Writer.WriteAsync(new CSVComputerStatus {
+                    await HandleCompStatusEvent(new CSVComputerStatus {
                         Status = privSessionResult.Collected ? StatusSuccess : privSessionResult.FailureReason,
                         Task = "NetWkstaUserEnum",
                         ComputerName = resolvedSearchResult.DisplayName,
                         ObjectId = resolvedSearchResult.ObjectId,
-                    }, _cancellationToken);
+                    });
 
                 if (!_context.Flags.NoRegistryLoggedOn) {
                     await _context.DoDelay();
@@ -326,12 +340,12 @@ namespace Sharphound.Runtime {
                         resolvedSearchResult.Domain, resolvedSearchResult.ObjectId);
                     ret.RegistrySessions = registrySessionResult;
                     if (_context.Flags.DumpComputerStatus)
-                        await compStatusChannel.Writer.WriteAsync(new CSVComputerStatus {
+                        await HandleCompStatusEvent(new CSVComputerStatus {
                             Status = registrySessionResult.Collected ? StatusSuccess : registrySessionResult.FailureReason,
                             Task = "RegistrySessions",
                             ComputerName = resolvedSearchResult.DisplayName,
                             ObjectId = resolvedSearchResult.ObjectId,
-                        }, _cancellationToken);
+                        });
                 }
             }
 
@@ -704,9 +718,7 @@ namespace Sharphound.Runtime {
             return ret;
         }
 
-        private async Task<EnterpriseCA> ProcessEnterpriseCA(IDirectoryObject entry,
-            ResolvedSearchResult resolvedSearchResult,
-            Channel<CSVComputerStatus> compStatusChannel) {
+        private async Task<EnterpriseCA> ProcessEnterpriseCA(IDirectoryObject entry, ResolvedSearchResult resolvedSearchResult) {
             var ret = new EnterpriseCA {
                 ObjectIdentifier = resolvedSearchResult.ObjectId,
                 Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult))
@@ -749,14 +761,13 @@ namespace Sharphound.Runtime {
                     if (await _context.LDAPUtils.ResolveHostToSid(dnsHostName, resolvedSearchResult.DomainSid) is
                             (true, var sid) && sid.StartsWith("S-1-")) {
                         ret.HostingComputer = sid;
-                        await compStatusChannel.Writer.WriteAsync(new CSVComputerStatus
+                        await HandleCompStatusEvent(new CSVComputerStatus
                             {
                                 Status = ComputerStatus.Success,
                                 ComputerName = resolvedSearchResult.DisplayName,
                                 Task = nameof(ProcessEnterpriseCA),
                                 ObjectId = resolvedSearchResult.ObjectId,
-                            },
-                            _cancellationToken);
+                            });
                     } else {
                         _log.LogWarning("CA {Name} host ({Dns}) could not be resolved to a SID.", caName, dnsHostName);
                     }
@@ -779,24 +790,23 @@ namespace Sharphound.Runtime {
                 if (caName != null && dnsHostName != null) {
                     if (await _context.LDAPUtils.ResolveHostToSid(dnsHostName, resolvedSearchResult.DomainSid) is
                             (true, var sid) && sid.StartsWith("S-1-")) {
-                        await compStatusChannel.Writer.WriteAsync(new CSVComputerStatus
+                        await HandleCompStatusEvent(new CSVComputerStatus
                         {
                             Status = ComputerStatus.Success,
                             ComputerName = resolvedSearchResult.DisplayName,
                             Task = nameof(ProcessEnterpriseCA),
                             ObjectId = sid,
-                        },
-                        _cancellationToken);
+                        });
                         ret.HostingComputer = sid;
                     } else {
                         _log.LogWarning("CA {Name} host ({Dns}) could not be resolved to a SID.", caName, dnsHostName);
                     }
 
                     CARegistryData cARegistryData = new() {
-                        IsUserSpecifiesSanEnabled = _certAbuseProcessor.IsUserSpecifiesSanEnabled(dnsHostName, caName),
+                        IsUserSpecifiesSanEnabled = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(dnsHostName, caName, ret.HostingComputer),
                         EnrollmentAgentRestrictions = await _certAbuseProcessor.ProcessEAPermissions(caName,
                             resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer),
-                        RoleSeparationEnabled = _certAbuseProcessor.RoleSeparationEnabled(dnsHostName, caName),
+                        RoleSeparationEnabled = await _certAbuseProcessor.RoleSeparationEnabled(dnsHostName, caName, ret.HostingComputer),
 
                         // The CASecurity exist in the AD object DACL and in registry of the CA server. We prefer to use the values from registry as they are the ground truth.
                         // If changes are made on the CA server, registry and the AD object is updated. If changes are made directly on the AD object, the CA server registry is not updated.

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -67,10 +67,22 @@ namespace Sharphound.Runtime {
             _log = log;
             _compStatusChannel = compStatusChannel;
 
+            _localGroupProcessor.ComputerStatusEvent += HandleCompStatusEvent;
+            _computerSessionProcessor.ComputerStatusEvent += HandleCompStatusEvent;
+            _userRightsAssignmentProcessor.ComputerStatusEvent += HandleCompStatusEvent;
+            _computerAvailability.ComputerStatusEvent += HandleCompStatusEvent;
+            _spnProcessor.ComputerStatusEvent += HandleCompStatusEvent;
+            _ldapPropertyProcessor.ComputerStatusEvent += HandleCompStatusEvent;
             _certAbuseProcessor.ComputerStatusEvent += HandleCompStatusEvent;
         }
 
         internal void ClearEventHandlers() {
+            _localGroupProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
+            _computerSessionProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
+            _userRightsAssignmentProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
+            _computerAvailability.ComputerStatusEvent -= HandleCompStatusEvent;
+            _spnProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
+            _ldapPropertyProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
             _certAbuseProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
         }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Update CertAbuseProcessor to write contacted machines to the compstatus log.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[BED-6967](https://specterops.atlassian.net/browse/BED-6967)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new unit tests and manually tested SHCE and SHE in a lab.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized status reporting into an event-driven flow and reduced parameter chaining between components.
  * Added explicit cleanup of event handlers after processing to avoid duplicate notifications and leaks.

* **Bug Fixes**
  * Removed stray formatting noise.
  * Made status/progress emission paths more consistent and reliable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[BED-6967]: https://specterops.atlassian.net/browse/BED-6967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ