### PR TITLE
Improve NTLM Collection Logging BED-7374

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -36,6 +36,9 @@
 <!--       <Reference Include="SharpHoundCommon">-->
 <!--           <HintPath>..\SharpHoundCommon\src\CommonLib\bin\Debug\net472\SharpHoundCommonLib.dll</HintPath>-->
 <!--       </Reference>-->
+<!--        <Reference Include="SharpHoundRPC">-->
+<!--            <HintPath>..\SharpHoundCommon\src\SharpHoundRPC\bin\Debug\net472\SharpHoundRPC.dll</HintPath>-->
+<!--        </Reference>-->
         <Reference Include="System.DirectoryServices" />
         <Reference Include="System.DirectoryServices.Protocols" />
         <Reference Include="System.IO.Compression" />

--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -25,8 +25,8 @@
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="SharpHoundCommon" Version="4.5.2" />
-        <PackageReference Include="SharpHoundRPC" Version="4.5.2" />
+        <PackageReference Include="SharpHoundCommon" Version="4.6.0-rc1" />
+        <PackageReference Include="SharpHoundRPC" Version="4.6.0-rc1" />
         <PackageReference Include="SharpZipLib" Version="1.3.3" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -41,7 +41,7 @@ namespace Sharphound.Runtime {
         private readonly SPNProcessors _spnProcessor;
         private readonly WebClientServiceProcessor _webClientProcessor;
         private readonly SmbProcessor _smbProcessor;
-        private readonly ConcurrentDictionary<string, RegistryProcessor> _registryProcessorMap = new();
+        private readonly ConcurrentDictionary<string, Lazy<RegistryProcessor>> _registryProcessorMap = new();
         private readonly Channel<CSVComputerStatus> _compStatusChannel;
         
         public ObjectProcessors(IContext context, ILogger log, Channel<CSVComputerStatus> compStatusChannel) {
@@ -86,8 +86,9 @@ namespace Sharphound.Runtime {
             _spnProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
             _ldapPropertyProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
             _certAbuseProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
-            foreach (var registryProcessor in _registryProcessorMap.Values) {
-                registryProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
+            foreach (var lazy in _registryProcessorMap.Values) {
+                if (lazy.IsValueCreated) 
+                    lazy.Value.ComputerStatusEvent -= HandleCompStatusEvent;
             }
         }
 
@@ -376,11 +377,13 @@ namespace Sharphound.Runtime {
 
             if (_methods.HasFlag(CollectionMethod.NTLMRegistry)) {
                 await _context.DoDelay();
-                var processor = _registryProcessorMap.GetOrAdd(resolvedSearchResult.DomainSid, _ => {
-                    var newProcessor = new RegistryProcessor(null, new StrategyExecutor(), resolvedSearchResult.Domain);
-                    newProcessor.ComputerStatusEvent += HandleCompStatusEvent;
-                    return newProcessor;
-                });
+                var processor = _registryProcessorMap.GetOrAdd(
+                    resolvedSearchResult.DomainSid,
+                    _ => new Lazy<RegistryProcessor>(() => {
+                        var newProcessor = new RegistryProcessor(null, new StrategyExecutor(), resolvedSearchResult.Domain);
+                        newProcessor.ComputerStatusEvent += HandleCompStatusEvent;
+                        return newProcessor;
+                    })).Value;
                 ret.NTLMRegistryData = await processor.ReadRegistrySettings(resolvedSearchResult.DisplayName);
             }
 

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -376,14 +376,12 @@ namespace Sharphound.Runtime {
 
             if (_methods.HasFlag(CollectionMethod.NTLMRegistry)) {
                 await _context.DoDelay();
-                if (_registryProcessorMap.TryGetValue(resolvedSearchResult.DomainSid, out var processor)) {
-                    ret.NTLMRegistryData = await processor.ReadRegistrySettings(resolvedSearchResult.DisplayName);
-                } else {
+                var processor = _registryProcessorMap.GetOrAdd(resolvedSearchResult.DomainSid, _ => {
                     var newProcessor = new RegistryProcessor(null, new StrategyExecutor(), resolvedSearchResult.Domain);
                     newProcessor.ComputerStatusEvent += HandleCompStatusEvent;
-                    _registryProcessorMap.TryAdd(resolvedSearchResult.DomainSid, newProcessor);
-                    ret.NTLMRegistryData = await newProcessor.ReadRegistrySettings(resolvedSearchResult.DisplayName);
-                }
+                    return newProcessor;
+                });
+                ret.NTLMRegistryData = await processor.ReadRegistrySettings(resolvedSearchResult.DisplayName);
             }
 
             if (_methods.HasFlag(CollectionMethod.WebClientService)) {

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -85,6 +85,9 @@ namespace Sharphound.Runtime {
             _spnProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
             _ldapPropertyProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
             _certAbuseProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
+            foreach (var registryProcessor in _registryProcessorMap.Values) {
+                registryProcessor.ComputerStatusEvent -= HandleCompStatusEvent;
+            }
         }
 
         private async Task HandleCompStatusEvent(CSVComputerStatus status) {
@@ -376,6 +379,7 @@ namespace Sharphound.Runtime {
                     ret.NTLMRegistryData = await processor.ReadRegistrySettings(resolvedSearchResult.DisplayName);
                 } else {
                     var newProcessor = new RegistryProcessor(null, resolvedSearchResult.Domain);
+                    newProcessor.ComputerStatusEvent += HandleCompStatusEvent;
                     _registryProcessorMap.TryAdd(resolvedSearchResult.DomainSid, newProcessor);
                     ret.NTLMRegistryData = await newProcessor.ReadRegistrySettings(resolvedSearchResult.DisplayName);
                 }

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -13,6 +13,7 @@ using SharpHoundCommonLib.DirectoryObjects;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
 using SharpHoundCommonLib.Processors;
+using SharpHoundRPC.Registry;
 using SharpHoundRPC.Wrappers;
 using Container = SharpHoundCommonLib.OutputTypes.Container;
 using Group = SharpHoundCommonLib.OutputTypes.Group;
@@ -378,7 +379,7 @@ namespace Sharphound.Runtime {
                 if (_registryProcessorMap.TryGetValue(resolvedSearchResult.DomainSid, out var processor)) {
                     ret.NTLMRegistryData = await processor.ReadRegistrySettings(resolvedSearchResult.DisplayName);
                 } else {
-                    var newProcessor = new RegistryProcessor(null, resolvedSearchResult.Domain);
+                    var newProcessor = new RegistryProcessor(null, new StrategyExecutor(), resolvedSearchResult.Domain);
                     newProcessor.ComputerStatusEvent += HandleCompStatusEvent;
                     _registryProcessorMap.TryAdd(resolvedSearchResult.DomainSid, newProcessor);
                     ret.NTLMRegistryData = await newProcessor.ReadRegistrySettings(resolvedSearchResult.DisplayName);


### PR DESCRIPTION
## Description

Add CompStatus Logging To Registry Processor
RunLog on Collection Failure
RegistryProcessor Unit Tests

## Motivation and Context

[BED-7374](https://specterops.atlassian.net/browse/BED-7374)

## How Has This Been Tested?

See SHCommon PR [#272](https://github.com/SpecterOps/SharpHoundCommon/pull/272)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-7374]: https://specterops.atlassian.net/browse/BED-7374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal initialization and lifecycle handling for registry processors to improve concurrency, caching, and event wiring; initialization is now deferred until first use.
  * Bumped internal package references to a newer release candidate.
  * No user-facing behavior or runtime changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->