### PR TITLE
feat: Add Metrics to SharpHound to be collected - BED-7080

### DIFF
--- a/src/Client/Flags.cs
+++ b/src/Client/Flags.cs
@@ -28,5 +28,6 @@ namespace Sharphound.Client
         public bool RecurseDomains { get; set; }
         public bool DoLocalAdminSessionEnum { get; set; }
         public bool ParititonLdapQueries { get; set; }
+        public bool Metrics { get; set; }
     }
 }

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -142,6 +142,9 @@ namespace Sharphound
         
         [Option(HelpText = "Split the main ldap query into smaller chunks to attempt to reduce server load")]
         public bool PartitionLdapQueries { get; set; }
+        
+        [Option(HelpText = "Output metrics that were captured from SharpHound")]
+        public bool Metrics { get; set; }
 
         //Loop Options
         [Option('l', "Loop", HelpText = "Loop computer collection")]

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -174,7 +174,8 @@ namespace Sharphound
                         
                         var metricsRouter = new MetricRouter(
                             metricsRegistry.Definitions,
-                            [fileSink]);
+                            [fileSink],
+                            new DefaultLabelValuesCache());
                         
                         Metrics.Factory = new MetricFactory(metricsRouter);
                         

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -166,9 +166,12 @@ namespace Sharphound
 
                         var metricsWriter = new MetricWriter();
                         
+                        var metricsFileName = string.IsNullOrEmpty(options.OutputPrefix) ? "metrics.log" : $"{options.OutputPrefix}_metrics.log";
+                        var metricsFilePath = System.IO.Path.Combine(options.OutputDirectory, metricsFileName);
+                        
                         var fileSink = new FileMetricSink(
                             metricsRegistry.Definitions,
-                            filePath: "metrics.log",
+                            filePath: metricsFilePath,
                             metricsWriter,
                             fileSinkOptions);
                         
@@ -189,7 +192,7 @@ namespace Sharphound
                 });
             } catch (Exception ex) {
                 logger.LogError($"Error running SharpHound: {ex.Message}\n{ex.StackTrace}");
-                _flushTimer.Dispose();
+                _flushTimer?.Dispose();
             }
         }
 
@@ -251,7 +254,7 @@ namespace Sharphound
             context = await links.AwaitLoopCompletion(context);
             context = links.SaveCacheFile(context);
             links.Finish(context);
-            _flushTimer.Dispose();
+            _flushTimer?.Dispose();
         }
 
         // Accessor function for the PS1 to work, do not change or remove

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -25,6 +25,9 @@ using Microsoft.Win32;
 using Sharphound.Client;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Enums;
+using SharpHoundCommonLib.Models;
+using SharpHoundCommonLib.Services;
+using SharpHoundCommonLib.Static;
 
 namespace Sharphound
 {
@@ -36,6 +39,8 @@ namespace Sharphound
     #region Console Entrypoint
 
     public class Program {
+        private static MetricsFlushTimer _flushTimer;
+        
         public static async Task Main(string[] args) {
             var logger = new BasicLogger((int)LogLevel.Information);
             logger.LogInformation("This version of SharpHound is compatible with the 5.0.0 Release of BloodHound");
@@ -88,7 +93,8 @@ namespace Sharphound
                         SearchForest = options.SearchForest,
                         RecurseDomains = options.RecurseDomains,
                         DoLocalAdminSessionEnum = options.DoLocalAdminSessionEnum,
-                        ParititonLdapQueries = options.PartitionLdapQueries
+                        ParititonLdapQueries = options.PartitionLdapQueries,
+                        Metrics = options.Metrics,
                     };
 
                     var ldapOptions = new LdapConfig
@@ -149,10 +155,40 @@ namespace Sharphound
                         }
                     }
 
+                    if (flags.Metrics) {
+                        var metricsRegistry = new MetricRegistry();
+                        metricsRegistry.RegisterDefaultMetrics();
+                        metricsRegistry.Seal();
+
+                        var fileSinkOptions = new FileMetricSinkOptions {
+                            FlushInterval = TimeSpan.FromSeconds(5),
+                        };
+
+                        var metricsWriter = new MetricWriter();
+                        
+                        var fileSink = new FileMetricSink(
+                            metricsRegistry.Definitions,
+                            filePath: "metrics.log",
+                            metricsWriter,
+                            fileSinkOptions);
+                        
+                        var metricsRouter = new MetricRouter(
+                            metricsRegistry.Definitions,
+                            [fileSink]);
+                        
+                        Metrics.Factory = new MetricFactory(metricsRouter);
+                        
+                        _flushTimer = new MetricsFlushTimer(
+                            flush: metricsRouter.Flush,
+                            interval: fileSinkOptions.FlushInterval);
+                        
+                    }
+
                     await StartCollection(options, logger, resolved, flags, ldapOptions);
                 });
             } catch (Exception ex) {
                 logger.LogError($"Error running SharpHound: {ex.Message}\n{ex.StackTrace}");
+                _flushTimer.Dispose();
             }
         }
 
@@ -214,6 +250,7 @@ namespace Sharphound
             context = await links.AwaitLoopCompletion(context);
             context = links.SaveCacheFile(context);
             links.Finish(context);
+            _flushTimer.Dispose();
         }
 
         // Accessor function for the PS1 to work, do not change or remove


### PR DESCRIPTION
## Description

Integrate with the metrics logic that is available in SharpHoundCommon.

## Motivation and Context

Resolves BED-7080

## How Has This Been Tested?

This has been tested by creating a build locally and running collection using the added functionality for metrics.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Metrics option to enable output of captured runtime metrics.
  * When enabled, metrics are collected and written to a file sink at regular intervals.
  * Output location respects configured output prefix and directory settings.
  * Metrics collection lifecycle is automatically managed and cleaned up to prevent resource leaks.
  * Default metrics filename is metrics.log unless overridden.
  * Metrics are flushed periodically (default 5-second interval).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->