### PR TITLE
fix: alter build to pull the next dev version - BED-7858

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -18,16 +18,23 @@
         <CommonLibsStableVersion>4.6.0</CommonLibsStableVersion>
         <CommonLibPath>..\SharpHoundCommon\src\CommonLib\bin\$(Configuration)\net472\SharpHoundCommonLib.dll</CommonLibPath>
         <RPCPath>..\SharpHoundCommon\src\SharpHoundRPC\bin\$(Configuration)\net472\SharpHoundRPC.dll</RPCPath>
-        
+
+        <!-- Derive the dev version by incrementing the patch of the stable version, mirroring
+             the auto-increment logic in SharpHoundCommon's publish-dev-package pipeline.
+             e.g. stable=4.6.0 → dev wildcard=4.6.1-dev* -->
+        <_StablePatch>$([System.Text.RegularExpressions.Regex]::Match($(CommonLibsStableVersion), '[0-9]+$').Value)</_StablePatch>
+        <_MajorMinor>$([System.Text.RegularExpressions.Regex]::Match($(CommonLibsStableVersion), '^[0-9]+\.[0-9]+').Value)</_MajorMinor>
+        <CommonLibsDevVersion>$(_MajorMinor).$([MSBuild]::Add($(_StablePatch), 1))-dev*</CommonLibsDevVersion>
+
         <CommonSource>Dev</CommonSource>
-        
+
         <!-- Determine if we should use local DLLs -->
         <_UseLocalLibs Condition="'$(CommonSource.ToLower())' == 'local'">true</_UseLocalLibs>
         <_UseLocalLibs Condition="'$(_UseLocalLibs)' == ''">false</_UseLocalLibs>
 
         <!-- Determine the package version -->
         <_CommonLibsVersion Condition="'$(CommonSource.ToLower())' == 'stable'">$(CommonLibsStableVersion)</_CommonLibsVersion>
-        <_CommonLibsVersion Condition="'$(_CommonLibsVersion)' == ''">$(CommonLibsStableVersion)-dev*</_CommonLibsVersion>
+        <_CommonLibsVersion Condition="'$(_CommonLibsVersion)' == ''">$(CommonLibsDevVersion)</_CommonLibsVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Description

This change finds the latest dev build based on a patch to the last stable. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This PR addresses: BED-7858

## How Has This Been Tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
-->

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system to automatically calculate development package versions based on stable version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->