### PR TITLE
Collect or skip custom deny aces count

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The listing below details the CLI arguments SharpHound supports. Additional deta
 
   --collectallproperties     Collect all LDAP properties from objects
 
+  --skipdenyacescount        Skip collecting custom deny ACE counts in LDAP object properties
+
   -l, --Loop                 Loop computer collection
 
   --loopduration             Loop duration (hh:mm:ss - 05:00:00 is 5 hours, default: 2 hrs)

--- a/src/Client/Flags.cs
+++ b/src/Client/Flags.cs
@@ -22,6 +22,7 @@ namespace Sharphound.Client
         public bool NoRegistryLoggedOn { get; set; }
         public bool DumpComputerStatus { get; set; }
         public bool CollectAllProperties { get; set; }
+        public bool SkipDenyAcesCount { get; set; }
         public bool DCOnly { get; set; }
         public bool PrettyPrint { get; set; }
         public bool SearchForest { get; set; }

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -139,6 +139,9 @@ namespace Sharphound
 
         [Option(HelpText = "Collect all LDAP properties from objects")]
         public bool CollectAllProperties { get; set; }
+
+        [Option(HelpText = "Skip collecting custom deny ACE counts in LDAP object properties")]
+        public bool SkipDenyAcesCount { get; set; }
         
         [Option(HelpText = "Split the main ldap query into smaller chunks to attempt to reduce server load")]
         public bool PartitionLdapQueries { get; set; }

--- a/src/PowerShell/Template.ps1
+++ b/src/PowerShell/Template.ps1
@@ -184,6 +184,10 @@
     .PARAMETER CollectAllProperties
 
         Collect all string LDAP properties on objects
+
+    .PARAMETER SkipDenyAcesCount
+
+        Skip collecting custom deny ACE counts in LDAP object properties
         
     .PARAMETER Loop
     
@@ -359,6 +363,9 @@
 
         [Switch]
         $CollectAllProperties,
+
+        [Switch]
+        $SkipDenyAcesCount,
 
         [Switch]
         $Loop,

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -581,7 +581,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps)) {
-                ret.Properties = ContextUtils.Merge(ret.Properties, LdapPropertyProcessor.ReadGPOProperties(entry));
+                ret.Properties = ContextUtils.Merge(ret.Properties, await _ldapPropertyProcessor.ReadGPOProperties(entry));
                 if (_context.Flags.CollectAllProperties) {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);
@@ -611,7 +611,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps)) {
-                ret.Properties = ContextUtils.Merge(ret.Properties, LdapPropertyProcessor.ReadOUProperties(entry));
+                ret.Properties = ContextUtils.Merge(ret.Properties, await _ldapPropertyProcessor.ReadOUProperties(entry));
                 if (_context.Flags.CollectAllProperties) {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);
@@ -662,7 +662,7 @@ namespace Sharphound.Runtime {
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
                 ret.Properties =
-                    ContextUtils.Merge(LdapPropertyProcessor.ReadContainerProperties(entry), ret.Properties);
+                    ContextUtils.Merge(await _ldapPropertyProcessor.ReadContainerProperties(entry), ret.Properties);
                 if (_context.Flags.CollectAllProperties) {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);
@@ -693,7 +693,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var props = LdapPropertyProcessor.ReadRootCAProperties(entry);
+                var props = await _ldapPropertyProcessor.ReadRootCAProperties(entry);
                 ret.Properties.Merge(props);
             }
 
@@ -724,7 +724,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var props = LdapPropertyProcessor.ReadAIACAProperties(entry);
+                var props = await _ldapPropertyProcessor.ReadAIACAProperties(entry);
                 ret.Properties.Merge(props);
             }
 
@@ -754,7 +754,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var props = LdapPropertyProcessor.ReadEnterpriseCAProperties(entry);
+                var props = await _ldapPropertyProcessor.ReadEnterpriseCAProperties(entry);
                 ret.Properties.Merge(props);
 
                 // Enabled cert templates
@@ -871,7 +871,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var props = LdapPropertyProcessor.ReadNTAuthStoreProperties(entry);
+                var props = await _ldapPropertyProcessor.ReadNTAuthStoreProperties(entry);
 
                 if (entry.TryGetByteArrayProperty(LDAPProperties.CACertificate, out var rawCertificates)) {
                     var certificates = from rawCertificate in rawCertificates
@@ -910,7 +910,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var certTemplatesProps = LdapPropertyProcessor.ReadCertTemplateProperties(entry);
+                var certTemplatesProps = await _ldapPropertyProcessor.ReadCertTemplateProperties(entry);
                 ret.Properties.Merge(certTemplatesProps);
             }
 

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -22,6 +22,8 @@ using Label = SharpHoundCommonLib.Enums.Label;
 namespace Sharphound.Runtime {
     public class ObjectProcessors {
         private const string StatusSuccess = "Success";
+        private const string CustomExplicitDenyAcesCountProperty = "customexplicitdenyacescount";
+        private const string CustomInheritedDenyAcesCountProperty = "custominheriteddenyacescount";
         private readonly ACLProcessor _aclProcessor;
         private readonly CertAbuseProcessor _certAbuseProcessor;
         private readonly CancellationToken _cancellationToken;
@@ -165,6 +167,28 @@ namespace Sharphound.Runtime {
             return null;
         }
 
+        private async Task<ACE[]> ProcessACL(IDirectoryObject entry, ResolvedSearchResult resolvedSearchResult,
+            Dictionary<string, object> properties) {
+            if (_context.Flags.SkipDenyAcesCount) {
+                return await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+            }
+
+            var result = await _aclProcessor.ProcessACLWithCustomDenyAces(resolvedSearchResult, entry);
+            AddCustomDenyAceCounts(properties, result.CustomDenyAceCounts);
+            return result.Aces;
+        }
+
+        private static void AddCustomDenyAceCounts(Dictionary<string, object> properties,
+            ACLProcessor.CustomDenyAceCounts counts) {
+            if (counts.Total == 0) {
+                return;
+            }
+
+            properties[CustomExplicitDenyAcesCountProperty] = counts.ExplicitCount;
+            properties[CustomInheritedDenyAcesCountProperty] = counts.InheritedCount;
+        }
+
         private async Task<User> ProcessUserObject(IDirectoryObject entry,
             ResolvedSearchResult resolvedSearchResult)
         {
@@ -185,8 +209,7 @@ namespace Sharphound.Runtime {
                 // AdminSDHolderProtected only on security principal nodes: User, Computer, Group
                 var adminSdHolderHash = GetAdminSdHolderHash(resolvedSearchResult.Domain);
 
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 var gmsa = entry.GetByteProperty(LDAPProperties.GroupMSAMembership);
@@ -262,8 +285,7 @@ namespace Sharphound.Runtime {
                 // AdminSDHolderProtected only on security principal nodes: User, Computer, Group
                 var adminSdHolderHash = GetAdminSdHolderHash(resolvedSearchResult.Domain);
 
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -475,8 +497,7 @@ namespace Sharphound.Runtime {
                 // AdminSDHolderProtected only on security principal nodes: User, Computer, Group
                 var adminSdHolderHash = GetAdminSdHolderHash(resolvedSearchResult.Domain);
 
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -528,8 +549,7 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Aces = aces;
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
@@ -571,8 +591,7 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -581,7 +600,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps)) {
-                ret.Properties = ContextUtils.Merge(ret.Properties, await _ldapPropertyProcessor.ReadGPOProperties(entry));
+                ret.Properties = ContextUtils.Merge(ret.Properties, LdapPropertyProcessor.ReadGPOProperties(entry));
                 if (_context.Flags.CollectAllProperties) {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);
@@ -600,8 +619,7 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -611,7 +629,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps)) {
-                ret.Properties = ContextUtils.Merge(ret.Properties, await _ldapPropertyProcessor.ReadOUProperties(entry));
+                ret.Properties = ContextUtils.Merge(ret.Properties, LdapPropertyProcessor.ReadOUProperties(entry));
                 if (_context.Flags.CollectAllProperties) {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);
@@ -650,8 +668,7 @@ namespace Sharphound.Runtime {
                 }
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -662,7 +679,7 @@ namespace Sharphound.Runtime {
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
                 ret.Properties =
-                    ContextUtils.Merge(await _ldapPropertyProcessor.ReadContainerProperties(entry), ret.Properties);
+                    ContextUtils.Merge(LdapPropertyProcessor.ReadContainerProperties(entry), ret.Properties);
                 if (_context.Flags.CollectAllProperties) {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);
@@ -683,8 +700,7 @@ namespace Sharphound.Runtime {
 
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -693,7 +709,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var props = await _ldapPropertyProcessor.ReadRootCAProperties(entry);
+                var props = LdapPropertyProcessor.ReadRootCAProperties(entry);
                 ret.Properties.Merge(props);
             }
 
@@ -714,8 +730,7 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -724,7 +739,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var props = await _ldapPropertyProcessor.ReadAIACAProperties(entry);
+                var props = LdapPropertyProcessor.ReadAIACAProperties(entry);
                 ret.Properties.Merge(props);
             }
 
@@ -744,8 +759,7 @@ namespace Sharphound.Runtime {
             };
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -754,7 +768,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var props = await _ldapPropertyProcessor.ReadEnterpriseCAProperties(entry);
+                var props = LdapPropertyProcessor.ReadEnterpriseCAProperties(entry);
                 ret.Properties.Merge(props);
 
                 // Enabled cert templates
@@ -861,8 +875,7 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -871,7 +884,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var props = await _ldapPropertyProcessor.ReadNTAuthStoreProperties(entry);
+                var props = LdapPropertyProcessor.ReadNTAuthStoreProperties(entry);
 
                 if (entry.TryGetByteArrayProperty(LDAPProperties.CACertificate, out var rawCertificates)) {
                     var certificates = from rawCertificate in rawCertificates
@@ -900,8 +913,7 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;
@@ -910,7 +922,7 @@ namespace Sharphound.Runtime {
             }
 
             if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var certTemplatesProps = await _ldapPropertyProcessor.ReadCertTemplateProperties(entry);
+                var certTemplatesProps = LdapPropertyProcessor.ReadCertTemplateProperties(entry);
                 ret.Properties.Merge(certTemplatesProps);
             }
 
@@ -932,8 +944,7 @@ namespace Sharphound.Runtime {
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
             if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.CertServices)) {
-                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
-                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                var aces = await ProcessACL(entry, resolvedSearchResult, ret.Properties);
                 ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
                 ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
                 ret.Aces = aces;

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -88,6 +88,7 @@ namespace Sharphound
                         RandomizeFilenames = options.RandomFileNames,
                         MemCache = options.MemCache,
                         CollectAllProperties = options.CollectAllProperties,
+                        SkipDenyAcesCount = options.SkipDenyAcesCount,
                         DCOnly = dconly,
                         PrettyPrint = options.PrettyPrint,
                         SearchForest = options.SearchForest,
@@ -104,8 +105,7 @@ namespace Sharphound
                         DisableSigning = options.DisableSigning,
                         ForceSSL = options.ForceSecureLDAP,
                         AuthType = AuthType.Negotiate,
-                        DisableCertVerification = options.DisableCertVerification,
-                        SkipDenyAcesCount = options.SkipDenyAcesCount
+                        DisableCertVerification = options.DisableCertVerification
                     };
 
                     if (options.DomainController != null) ldapOptions.Server = options.DomainController;

--- a/src/Sharphound.cs
+++ b/src/Sharphound.cs
@@ -104,7 +104,8 @@ namespace Sharphound
                         DisableSigning = options.DisableSigning,
                         ForceSSL = options.ForceSecureLDAP,
                         AuthType = AuthType.Negotiate,
-                        DisableCertVerification = options.DisableCertVerification
+                        DisableCertVerification = options.DisableCertVerification,
+                        SkipDenyAcesCount = options.SkipDenyAcesCount
                     };
 
                     if (options.DomainController != null) ldapOptions.Server = options.DomainController;


### PR DESCRIPTION
## Description

Adds SharpHound support for custom deny ACE count collection from SharpHoundCommon.

This wires the new `LdapConfig.SkipDenyAcesCount` setting into SharpHound, exposes the matching `--skipdenyacescount` CLI option, and updates the PowerShell wrapper and README help text to use the count-oriented name.

## Motivation and Context

SharpHoundCommon now reports custom explicit and inherited deny ACE counts as LDAP object properties. SharpHound needs to pass through the opt-out setting so operators can skip that collection path when desired.

This PR addresses: BED-8117

Related PRs:

BloodHound: https://github.com/SpecterOps/BloodHound/pull/2779
SharpHoundCommon: https://github.com/SpecterOps/SharpHoundCommon/pull/298
SharpHoundEnterprise: https://github.com/SpecterOps/sharphound-enterprise/pull/113

## How Has This Been Tested?

Tested locally against the sibling `SharpHoundCommon` `BED-8117-deny-aces` branch using local DLL references.

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skipdenyacescount` command-line argument to skip collection of custom deny Access Control Entry (ACE) counts from LDAP object properties during enumeration.
  * Introduced `-SkipDenyAcesCount` PowerShell switch parameter for PowerShell-based enumeration workflows.

* **Documentation**
  * Updated documentation to reference the new command-line argument and its functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/SharpHound/pull/218)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->