### PR TITLE
Disposing Timer and CancellationTokenSource

### DIFF
--- a/src/BaseContext.cs
+++ b/src/BaseContext.cs
@@ -161,6 +161,32 @@ namespace Sharphound
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer
                 // TODO: set large fields to null
+                Timer = null;
+                CancellationTokenSource = null;
+                ResolvedCollectionMethods = null;
+                Logger = null;
+                LoopEnd = null;
+                LDAPUtils = null;
+                LoopDuration = null;
+                LoopInterval = null;
+                CurrentLoopTime = String.Empty;
+                CollectionTask = null;
+                StatusInterval = 0;
+                Threads = 0;
+                Throttle = 0;
+                Jitter = 0;
+                PortScanTimeout = 0;
+                LdapFilter = String.Empty;
+                SearchBase = String.Empty;
+                DomainName = String.Empty;
+                CacheFileName = String.Empty;
+                ComputerFile = String.Empty;
+                ZipFilename = String.Empty;
+                ZipPassword = String.Empty;
+                CurrentUserName = String.Empty;
+                RealDNSName = String.Empty;
+                OutputPrefix = String.Empty;
+                OutputDirectory = String.Empty;
                 disposedValue = true;
             }
         }

--- a/src/BaseContext.cs
+++ b/src/BaseContext.cs
@@ -163,6 +163,7 @@ namespace Sharphound
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer
                 // TODO: set large fields to null
+                disposedValue = true;
             }
         }
     }

--- a/src/BaseContext.cs
+++ b/src/BaseContext.cs
@@ -157,37 +157,12 @@ namespace Sharphound
                 if (disposing)
                 {
                     // TODO: dispose managed state (managed objects)
+                    Timer?.Dispose();
+                    CancellationTokenSource?.Dispose();
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer
                 // TODO: set large fields to null
-                Timer = null;
-                CancellationTokenSource = null;
-                ResolvedCollectionMethods = null;
-                Logger = null;
-                LoopEnd = null;
-                LDAPUtils = null;
-                LoopDuration = null;
-                LoopInterval = null;
-                CurrentLoopTime = String.Empty;
-                CollectionTask = null;
-                StatusInterval = 0;
-                Threads = 0;
-                Throttle = 0;
-                Jitter = 0;
-                PortScanTimeout = 0;
-                LdapFilter = String.Empty;
-                SearchBase = String.Empty;
-                DomainName = String.Empty;
-                CacheFileName = String.Empty;
-                ComputerFile = String.Empty;
-                ZipFilename = String.Empty;
-                ZipPassword = String.Empty;
-                CurrentUserName = String.Empty;
-                RealDNSName = String.Empty;
-                OutputPrefix = String.Empty;
-                OutputDirectory = String.Empty;
-                disposedValue = true;
             }
         }
     }

--- a/src/Producers/LdapProducer.cs
+++ b/src/Producers/LdapProducer.cs
@@ -147,10 +147,9 @@ namespace Sharphound.Producers
 
                             if (searchResult.TryGetDistinguishedName(out var distinguishedName))
                             {
-                                var lower = distinguishedName.ToLower();
-                                if (lower.Contains("cn=domainupdates,cn=system"))
+                                if (distinguishedName.Contains("cn=domainupdates,cn=system", StringComparison.OrdinalIgnoreCase))
                                     continue;
-                                if (lower.Contains("cn=policies,cn=system") && (lower.StartsWith("cn=user") || lower.StartsWith("cn=machine")))
+                                if (distinguishedName.Contains("cn=policies,cn=system", StringComparison.OrdinalIgnoreCase) && (distinguishedName.StartsWith("cn=user", StringComparison.OrdinalIgnoreCase) || distinguishedName.StartsWith("cn=machine", StringComparison.OrdinalIgnoreCase)))
                                     continue;
 
                                 await Channel.Writer.WriteAsync(searchResult, cancellationToken);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Disposing items inside Dispose
- Timer?.Dispose();
- CancellationTokenSource?.Dispose();

This PR addresses: [GitHub issue or Jira ticket number]

## How Has This Been Tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
-->

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup during shutdown to ensure timers and cancellation tokens are properly released.
  * Fixed LDAP result filtering to more reliably exclude specific system entries regardless of case, reducing incorrect inclusions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/SharpHound/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->