### PR TITLE
chore: bump SH version for RC 2.13.0-rc1 - BED-8300

### DIFF
--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -6,8 +6,8 @@
         <LangVersion>latest</LangVersion>
         <DebugType>full</DebugType>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>2.12.0</Version>
-        <FileVersion>2.12.0</FileVersion>
+        <Version>2.13.0-rc1</Version>
+        <FileVersion>2.13.0-rc1</FileVersion>
         <Company>SpecterOps</Company>
         <Product>SharpHound</Product>
         <AssemblyName>SharpHound</AssemblyName>

--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
     
     <PropertyGroup>
-        <CommonLibsVersion>4.6.1</CommonLibsVersion>
+        <CommonLibsVersion>4.6.2-rc1</CommonLibsVersion>
         <CommonSource>Dev</CommonSource>
         <_CommonSource>$(CommonSource.ToLower())</_CommonSource>
         <_CommonLibPath>..\SharpHoundCommon\src\CommonLib\bin\$(Configuration)\net472\SharpHoundCommonLib.dll</_CommonLibPath>
@@ -50,8 +50,8 @@
         </Reference>
     </ItemGroup>
     <ItemGroup Condition="'$(_CommonSource)' != 'local'">
-        <PackageReference Include="SharpHoundCommon" Version="$(_ResolvedCommonVersion)" />
-        <PackageReference Include="SharpHoundRPC" Version="$(_ResolvedCommonVersion)" />
+        <PackageReference Include="SharpHoundCommon" Version="4.6.2-rc1" />
+        <PackageReference Include="SharpHoundRPC" Version="4.6.2-rc1" />
     </ItemGroup>
     
     <Target Name="LogCommonLibsSource" BeforeTargets="Build">

--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -7,7 +7,8 @@
         <DebugType>full</DebugType>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
         <Version>2.13.0-rc1</Version>
-        <FileVersion>2.13.0-rc1</FileVersion>
+        <FileVersion>2.13.0</FileVersion>
+        <InformationalVersion>2.13.0-rc1</InformationalVersion>
         <Company>SpecterOps</Company>
         <Product>SharpHound</Product>
         <AssemblyName>SharpHound</AssemblyName>

--- a/Sharphound.csproj
+++ b/Sharphound.csproj
@@ -50,8 +50,8 @@
         </Reference>
     </ItemGroup>
     <ItemGroup Condition="'$(_CommonSource)' != 'local'">
-        <PackageReference Include="SharpHoundCommon" Version="4.6.2-rc1" />
-        <PackageReference Include="SharpHoundRPC" Version="4.6.2-rc1" />
+        <PackageReference Include="SharpHoundCommon" Version="$(_ResolvedCommonVersion)" />
+        <PackageReference Include="SharpHoundRPC" Version="$(_ResolvedCommonVersion)" />
     </ItemGroup>
     
     <Target Name="LogCommonLibsSource" BeforeTargets="Build">


### PR DESCRIPTION
## Description

This change updates the SHC library to the RC version, as well as changing the version of the SH library to an RC version for cutting the prerelease. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This PR addresses: BED-8300

## How Has This Been Tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
-->

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated product version metadata to 2.13.0-rc1 (release candidate).
  * Updated shared dependency metadata to 4.6.2-rc1.
  * Metadata-only changes; no functional or behavioral changes visible to users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/SharpHound/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->